### PR TITLE
Build schemas into single files and embed them

### DIFF
--- a/.ci/test-cover
+++ b/.ci/test-cover
@@ -16,6 +16,7 @@ grcov "${DESTDIR}" \
     --ignore "$HOME/.cargo/**" \
     --ignore-not-existing \
     --ignore 'tests/**' \
+    --ignore 'build.rs' \
     --excl-start '#(\[cfg\(test\)\]|\[test\])' \
     --llvm \
     --binary-path "target/debug/" \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,8 @@ serde_json = "1.0"
 spdx = "0.10.6"
 wax = "0.6.0"
 
+[build-dependencies]
+wax = "0.6.0"
+serde_json = "1.0"
+
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@ PGXN Meta Spec
 ==============
 
 [![PostgreSQL License](https://img.shields.io/badge/License-PostgreSQL-blue.svg)](https://opensource.org/licenses/PostgreSQL "⚖️ PostgreSQL License")
-[![Build Status](https://github.com/pgxn/meta/actions/workflows/test-and-lint/badge.svg)](https://github.com/pgxn/meta/actions
-workflows/test-and-lint "🧪 Test and Lint")
+[![Build Status](https://github.com/pgxn/meta/actions/workflows/test-and-lint.yml/badge.svg)](https://github.com/pgxn/meta/actions/workflows/test-and-lint "🧪 Test and Lint")
 [![Code Coverage](https://codecov.io/gh/pgxn/meta/graph/badge.svg?token=5DOLLPIHEO)](https://codecov.io/gh/pgxn/meta "📊 Code Coverage")
 
 The PGXN Meta Spec defines the requirements for the metadata file

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,41 @@
+// build.rs
+
+use serde_json::{map::Map, Value};
+use std::{env, error::Error, fs::File, path::Path};
+use wax::Glob;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    merge_version(1)?;
+    merge_version(2)?;
+    println!("cargo::rerun-if-changed=schema");
+    println!("cargo::rerun-if-changed=build.rs");
+    Ok(())
+}
+
+fn merge_version(version: u8) -> Result<(), Box<dyn Error>> {
+    let src_dir = Path::new("schema").join(format!("v{version}"));
+    let glob = Glob::new("*.schema.json")?;
+    let mut defs = serde_json::map::Map::new();
+
+    for path in glob.walk(src_dir) {
+        let path = &path?.into_path();
+        let schema: Map<String, Value> = serde_json::from_reader(File::open(path)?)?;
+        // let id = schema["$id"].as_str().ok_or("No $id found in {path}")?;
+        let id = path.file_name().unwrap().to_str().unwrap();
+        defs.insert(id.to_string(), Value::Object(schema));
+    }
+
+    const ROOT: &str = "distribution.schema.json";
+    let mut dist = defs.remove(ROOT).unwrap();
+    dist.as_object_mut()
+        .unwrap()
+        .insert("$defs".to_string(), Value::Object(defs));
+
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let dst_file = format!("pgxn-meta-v{version}.schema.json");
+    let dst_path = Path::new(&out_dir).join(&dst_file);
+    let file = File::create(dst_path)?;
+    serde_json::to_writer(&file, &dist)?;
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,6 @@ use std::{path::PathBuf, error::Error};
 use serde_json::json;
 use pgxn_meta::*;
 
-let schemas_dir: PathBuf = [env!("CARGO_MANIFEST_DIR"), "schema"].iter().collect();
-let mut validator = Validator::new(schemas_dir)?;
 
 let meta = json!({
   "name": "pair",
@@ -33,6 +31,7 @@ let meta = json!({
   "meta-spec": { "version": "2.0.0" }
 });
 
+let mut validator = Validator::new();
 assert!(validator.validate(&meta).is_ok());
 # Ok::<(), Box<dyn Error>>(())
 ```
@@ -42,8 +41,8 @@ assert!(validator.validate(&meta).is_ok());
 
 */
 
-mod valid;
-pub use valid::{ValidationError, Validator};
-
 #[doc(hidden)]
 pub mod compiler;
+
+mod valid;
+pub use valid::{ValidationError, Validator};

--- a/tests/v1_schema_test.rs
+++ b/tests/v1_schema_test.rs
@@ -6,7 +6,6 @@ use serde_json::{json, Map, Value};
 // importing common module.
 mod common;
 use common::*;
-use pgxn_meta::compiler;
 
 const SCHEMA_VERSION: u8 = 1;
 
@@ -18,21 +17,21 @@ fn test_schema_v1() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v1_term() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the term schema.
-    let compiler = compiler::new("schema/v1")?;
+    let compiler = new_compiler("schema/v1")?;
     test_term_schema(compiler, SCHEMA_VERSION)
 }
 
 #[test]
 fn test_v1_tags() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the tags schema.
-    let compiler = compiler::new("schema/v1")?;
+    let compiler = new_compiler("schema/v1")?;
     test_tags_schema(compiler, SCHEMA_VERSION)
 }
 
 #[test]
 fn test_v1_version() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the version schema.
-    let mut compiler = compiler::new("schema/v1")?;
+    let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "version");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -57,7 +56,7 @@ fn test_v1_version() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v1_version_range() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the version_range schema.
-    let mut compiler = compiler::new("schema/v1")?;
+    let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "version_range");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -128,7 +127,7 @@ fn test_v1_version_range() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v1_license() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the license schema.
-    let mut compiler = compiler::new("schema/v1")?;
+    let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "license");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -197,7 +196,7 @@ fn test_v1_license() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v1_provides() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the provides schema.
-    let mut compiler = compiler::new("schema/v1")?;
+    let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "provides");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -296,7 +295,7 @@ fn test_v1_provides() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v1_extension() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the extension schema.
-    let mut compiler = compiler::new("schema/v1")?;
+    let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "extension");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -472,7 +471,7 @@ fn test_v1_extension() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v1_maintainer() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the maintainer schema.
-    let mut compiler = compiler::new("schema/v1")?;
+    let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "maintainer");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -522,7 +521,7 @@ fn test_v1_maintainer() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v1_meta_spec() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the maintainer schema.
-    let mut compiler = compiler::new("schema/v1")?;
+    let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "meta-spec");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -576,7 +575,7 @@ fn test_v1_meta_spec() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v1_bugtracker() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the maintainer schema.
-    let mut compiler = compiler::new("schema/v1")?;
+    let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "bugtracker");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -630,7 +629,7 @@ fn test_v1_bugtracker() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v1_no_index() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the maintainer schema.
-    let mut compiler = compiler::new("schema/v1")?;
+    let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "no_index");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -697,7 +696,7 @@ fn test_v1_no_index() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v1_prereq_relationship() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the maintainer schema.
-    let mut compiler = compiler::new("schema/v1")?;
+    let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "prereq_relationship");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -750,7 +749,7 @@ fn test_v1_prereq_relationship() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v1_prereq_phase() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the maintainer schema.
-    let mut compiler = compiler::new("schema/v1")?;
+    let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "prereq_phase");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -862,7 +861,7 @@ fn test_v1_prereq_phase() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v1_prereqs() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the maintainer schema.
-    let mut compiler = compiler::new("schema/v1")?;
+    let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "prereqs");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -1010,7 +1009,7 @@ fn test_v1_prereqs() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v1_repository() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the repository schema.
-    let mut compiler = compiler::new("schema/v1")?;
+    let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "repository");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -1087,7 +1086,7 @@ fn test_v1_repository() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v1_resources() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the resources schema.
-    let mut compiler = compiler::new("schema/v1")?;
+    let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "resources");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -1224,7 +1223,7 @@ fn valid_distribution() -> Value {
 #[test]
 fn test_v1_distribution() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the distribution schema.
-    let mut compiler = compiler::new("schema/v1")?;
+    let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "distribution");
     let idx = compiler.compile(&id, &mut schemas)?;

--- a/tests/v2_schema_test.rs
+++ b/tests/v2_schema_test.rs
@@ -6,7 +6,6 @@ use serde_json::{json, Map, Value};
 // importing common module.
 mod common;
 use common::*;
-use pgxn_meta::compiler;
 
 const SCHEMA_VERSION: u8 = 2;
 
@@ -18,21 +17,21 @@ fn test_schema_v2() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v2_term() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the term schema.
-    let compiler = compiler::new("schema/v2")?;
+    let compiler = new_compiler("schema/v2")?;
     test_term_schema(compiler, SCHEMA_VERSION)
 }
 
 #[test]
 fn test_v2_tags() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the tags schema.
-    let compiler = compiler::new("schema/v2")?;
+    let compiler = new_compiler("schema/v2")?;
     test_tags_schema(compiler, SCHEMA_VERSION)
 }
 
 #[test]
 fn test_v2_semver() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the semver schema.
-    let mut compiler = compiler::new("schema/v2")?;
+    let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "semver");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -62,7 +61,7 @@ fn test_v2_semver() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v2_path() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the semver schema.
-    let mut compiler = compiler::new("schema/v2")?;
+    let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "path");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -106,7 +105,7 @@ fn test_v2_path() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v2_glob() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the semver schema.
-    let mut compiler = compiler::new("schema/v2")?;
+    let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "glob");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -147,7 +146,7 @@ fn test_v2_glob() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v2_version_range() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the version_range schema.
-    let mut compiler = compiler::new("schema/v2")?;
+    let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "version_range");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -217,7 +216,7 @@ fn test_v2_version_range() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v2_license() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the semver schema.
-    let mut compiler = compiler::new("schema/v2")?;
+    let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "license");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -267,7 +266,7 @@ fn test_v2_license() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v2_purl() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the semver schema.
-    let mut compiler = compiler::new("schema/v2")?;
+    let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "purl");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -311,7 +310,7 @@ fn test_v2_purl() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v2_platform() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the semver schema.
-    let mut compiler = compiler::new("schema/v2")?;
+    let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "platform");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -397,7 +396,7 @@ fn test_v2_platform() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v2_platforms() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the semver schema.
-    let mut compiler = compiler::new("schema/v2")?;
+    let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "platforms");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -445,7 +444,7 @@ fn test_v2_platforms() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v2_maintainers() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the maintainer schema.
-    let mut compiler = compiler::new("schema/v2")?;
+    let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "maintainers");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -583,7 +582,7 @@ fn test_v2_maintainers() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v2_extension() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the extension schema.
-    let mut compiler = compiler::new("schema/v2")?;
+    let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "extension");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -760,7 +759,7 @@ fn test_v2_extension() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v2_module() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the extension schema.
-    let mut compiler = compiler::new("schema/v2")?;
+    let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "module");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -929,7 +928,7 @@ fn test_v2_module() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v2_app() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the extension schema.
-    let mut compiler = compiler::new("schema/v2")?;
+    let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "app");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -1043,7 +1042,7 @@ fn test_v2_app() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v2_contents() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the extension schema.
-    let mut compiler = compiler::new("schema/v2")?;
+    let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "contents");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -1182,7 +1181,7 @@ fn test_v2_contents() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v2_meta_spec() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the maintainer schema.
-    let mut compiler = compiler::new("schema/v2")?;
+    let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "meta-spec");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -1236,7 +1235,7 @@ fn test_v2_meta_spec() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v2_categories() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the maintainer schema.
-    let mut compiler = compiler::new("schema/v2")?;
+    let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "categories");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -1305,7 +1304,7 @@ fn test_v2_categories() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v2_classifications() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the maintainer schema.
-    let mut compiler = compiler::new("schema/v2")?;
+    let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "classifications");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -1376,7 +1375,7 @@ fn test_v2_classifications() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v2_ignore() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the semver schema.
-    let mut compiler = compiler::new("schema/v2")?;
+    let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "ignore");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -1434,7 +1433,7 @@ fn test_v2_ignore() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v2_phase() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the maintainer schema.
-    let mut compiler = compiler::new("schema/v2")?;
+    let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "phase");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -1561,7 +1560,7 @@ fn test_v2_phase() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v2_packages() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the maintainer schema.
-    let mut compiler = compiler::new("schema/v2")?;
+    let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "packages");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -1715,7 +1714,7 @@ fn test_v2_packages() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v2_postgres() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the maintainer schema.
-    let mut compiler = compiler::new("schema/v2")?;
+    let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "postgres");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -1775,7 +1774,7 @@ fn test_v2_postgres() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v2_pipeline() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the semver schema.
-    let mut compiler = compiler::new("schema/v2")?;
+    let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "pipeline");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -1819,7 +1818,7 @@ fn test_v2_pipeline() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v2_dependencies() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the maintainer schema.
-    let mut compiler = compiler::new("schema/v2")?;
+    let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "dependencies");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -2074,7 +2073,7 @@ fn test_v2_dependencies() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v2_variations() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the maintainer schema.
-    let mut compiler = compiler::new("schema/v2")?;
+    let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "variations");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -2204,7 +2203,7 @@ fn test_v2_variations() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v2_badges() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the maintainer schema.
-    let mut compiler = compiler::new("schema/v2")?;
+    let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "badges");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -2317,7 +2316,7 @@ fn test_v2_badges() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v2_resources() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the maintainer schema.
-    let mut compiler = compiler::new("schema/v2")?;
+    let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "resources");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -2443,7 +2442,7 @@ fn test_v2_resources() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_v2_artifacts() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the maintainer schema.
-    let mut compiler = compiler::new("schema/v2")?;
+    let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "artifacts");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -2889,7 +2888,7 @@ fn valid_v2_distribution() -> Value {
 #[test]
 fn test_v2_distribution() -> Result<(), Box<dyn Error>> {
     // Load the schemas and compile the distribution schema.
-    let mut compiler = compiler::new("schema/v2")?;
+    let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "distribution");
     let idx = compiler.compile(&id, &mut schemas)?;


### PR DESCRIPTION
Add `build.rs`, a [Rust build script], which compiles the v1 and v2 schemas into single files named `pgxn-meta-v1.schema.json` and `pgxn-meta-v2.schema.json`. Then teach compiler::new() to create a compiler with these files. Since they're embedded in the binary thanks to `include_str!()`, they should never fail to parse and load, so unwrap all the errors.

Teach Validator::new() to use the updated compiler::new(), and likewise remove the Result return value, since the files are compiled.

The integration tests still need to load schemas directly from files, so they can be referenced by their IDs, so move that functionality to the common module. Requires that `spec_compiler()` be public. This stuff should be moved to unit tests TBH.

While at it, remove the boolean return value from `validate()`; it was never used.

  [Rust build script]: https://doc.rust-lang.org/cargo/reference/build-scripts.html