### PR TITLE
Generate release notes and add 2 Platforms

### DIFF
--- a/.ci/mknotes
+++ b/.ci/mknotes
@@ -1,0 +1,163 @@
+#!/usr/bin/env perl
+
+package mknotes;
+
+use strict;
+use warnings;
+use v5.30;
+use Getopt::Long qw(GetOptions);
+use File::Path qw(make_path);
+use File::Basename qw(dirname);
+use utf8;
+
+my $item_regex = qr/^[*-+]\s+/;
+my $indent_regex = qr/^\s+/;
+my $version_regex = qr/^version\s*=\s*["']([^"']+)/;
+
+sub new {
+    my $self = {
+        cargo   => 'Cargo.toml',
+        file    => '',
+        repo    => '',
+        output  => '',
+    };
+
+    GetOptions(
+        "f=s" => \$self->{file},
+        "c=s" => \$self->{cargo},
+        "r=s" => \$self->{repo},
+        "o=s" => \$self->{output},
+    ) or die("Error in command line arguments\n");
+
+    if (!$self->{file} || !$self->{repo}) {
+        die "Usage: mknotes -f <CHANGELOG> -r <REPO> [-c <CARGO_TOML>] [ -o <OUTPUT_FILE>]\n";
+	}
+
+	# Trim a slash from the URI.
+    $self->{repo} =~ s{/$}{};
+
+	bless $self => __PACKAGE__;
+}
+
+sub run {
+    my $self = shift;
+    my $version = $self->parse_version;
+
+    open my $fh, '<:encoding(UTF-8)', $self->{file}
+        or die "Cannot open $self->{file}: $!\n";
+
+	# Print to STDOUT by default.
+    my $out;
+    if ($self->{output}) {
+        my $dir = dirname $self->{output};
+        make_path $dir unless -d $dir;
+        open $out, '>:encoding(UTF-8)', $self->{output}
+            or die "Cannot open $self->{output}: $!\n";
+    } else {
+        $out = \*STDOUT;
+        binmode $out, ':encoding(UTF-8)';
+    }
+
+
+	my $header = "## [v$self->{version}]";
+	my ($found, $in_item) = (0, 0);
+
+    while (my $line = <$fh>) {
+        if ($line =~ /^\Q$header/) {
+			# Found the header for this version. Build a regex for its link
+			# reference.
+			$found = 1;
+            my $link_regex = qr/^\s*\Q[v$self->{version}]\E:\s+https:/;
+
+			# Continue scanning until we reach the next `## ` header.
+            while (my $line = <$fh>) {
+                chomp $line;
+                return $self->finish_list($out, $line) if $line =~ /^## /;
+
+			    # Skip the line if it's the link reference for the header.
+                $in_item = $self->print_line($out, $line, $in_item)
+                    unless $line =~ $link_regex;
+			}
+        }
+    }
+
+    # All done!
+    die "Version $self->{version} not found in $self->{file}\n" unless $found;
+}
+
+# Called when the next version header is found in line.
+sub finish_list {
+    my ($self, $out, $line) = @_;
+	# Next header. Extract its version.
+
+    my ($prev) = $line =~ /\[([^]]+)\]/;
+	die "No version found in $line\n" unless $prev;
+
+	# Emit a footer line with a link to the diff for this version.
+    print {$out} sprintf(
+		"---\n\n🆚 For more detail compare [changes since %s](%s/compare/%s...%s).\n",
+		$prev, $self->{repo}, $prev, $self->{version},
+	);
+
+	# All done.
+	return 1;
+}
+
+# Called for a line to print, keeping track of list item status.
+sub print_line {
+    my ($self, $out, $line, $in_item) = @_;
+	# Convert wrapped list items to single lines.
+    if ($line =~ $item_regex) {
+		if ($in_item) {
+			# Previous item done
+            print {$out} "\n";
+		} else {
+			# We're in an item now.
+			$in_item = 1
+		}
+		# Print the line with no newline.
+        print {$out} $line;
+
+		return $in_item;
+	}
+
+	if ($in_item) {
+		# In an item, but not starting a new item.
+		if ($line =~ $indent_regex) {
+			# Continued item, convert indent to single space.
+			$line =~ s/$indent_regex/ /g;
+			# Print without newline.
+            print {$out} $line;
+		} else {
+			# No longer in an item.
+			$in_item = 0;
+			# Previous item done; print complete line.
+            print {$out} "\n", $line, "\n";
+		}
+
+		return $in_item;
+	}
+
+	# Not in an item.
+	$in_item = 0;
+	# Print complete line
+    print {$out} $line, "\n";
+
+	return $in_item;
+}
+
+sub parse_version {
+    my $self = shift;
+    open my $fh, '<:encoding(UTF-8)', $self->{cargo}
+        or die "Cannot open $self->{cargo}: $!\n";
+    while (<$fh>) {
+        return $self->{version} = $1 if /$version_regex/;
+    }
+    die "Version field not found in $self->{cargo}\n";
+}
+
+package main;
+
+mknotes->new->run;
+
+__END__

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -17,10 +17,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # https://github.com/cross-rs/cross#supported-targets
         platform:
           - os_name: freebsd-amd64
             os: ubuntu-20.04
             target: x86_64-unknown-freebsd
+            bin: pgxn_meta
+            emoji: 😈
+            skip_tests: true
+          - os_name: freebsd-i686
+            os: ubuntu-20.04
+            target: i686-unknown-freebsd
             bin: pgxn_meta
             emoji: 😈
             skip_tests: true
@@ -97,12 +104,12 @@ jobs:
             bin: pgxn_meta.exe
             emoji: 🪟
           - os_name: darwin-amd64
-            os: darwin-latest
+            os: macos-latest
             target: x86_64-apple-darwin
             bin: pgxn_meta
             emoji: 🍎
           - os_name: darwin-arm64
-            os: darwin-latest
+            os: macos-latest
             target: aarch64-apple-darwin
             bin: pgxn_meta
             emoji: 🍎
@@ -112,6 +119,25 @@ jobs:
             bin: pgxn_meta
             emoji: 🐦‍🔥
             skip_tests: true
+          - os_name: solaris-sparcv9
+            os: ubuntu-20.04
+            target: sparcv9-sun-solaris
+            bin: pgxn_meta
+            emoji: ☀️
+            skip_tests: true
+          # https://github.com/cross-rs/cross/issues/1536
+          # - os_name: solaris-amd64
+          #   os: ubuntu-20.04
+          #   target: x86_64-pc-solaris
+          #   bin: pgxn_meta
+          #   emoji: ☀️
+          # Dragonfly: No std component available.
+          # - os_name: dragonfly-amd64
+          #   os: ubuntu-20.04
+          #   target: x86_64-unknown-dragonfly
+          #   bin: pgxn_meta
+          #   emoji: 🐉🪰
+          #   skip_tests: true
         toolchain:
           - stable
           - beta
@@ -179,10 +205,13 @@ jobs:
               exit 1
           fi
         if: matrix.toolchain == 'stable' && startsWith( github.ref, 'refs/tags/v' )
+      - name: Generate Release Changes
+        run: make target/release-notes.md
+        if: matrix.toolchain == 'stable' && github.ref == 'refs/tags/test-release'
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           draft: true
           files: "pgxn_meta*"
-          body_path: CHANGELOG.md
+          body_path: target/release-notes.md
         if: matrix.toolchain == 'stable' && startsWith( github.ref, 'refs/tags/v' )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file. It uses the
   [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
     "Semantic Versioning 2.0.0"
 
-## [v0.1.0] — 2024-08-07
+## [v0.1.0] — 2024-08-08
 
 The theme of this release is *Cross Compilation.*
 

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,6 @@ docs: target/doc/pgxn_meta/index.html
 
 target/doc/pgxn_meta/index.html: $(shell find . -name \*.rs)
 	cargo doc
+
+target/release-notes.md: CHANGELOG.md .ci/mknotes Cargo.toml
+	@./.ci/mknotes -f $< -r https://github.com/$(or $(GITHUB_REPOSITORY),theory/meta) -o $@


### PR DESCRIPTION
Copy `.ci/mknotes` from pgxn/pg-jsonschema-boon and modify it to read the version from `Cargo.toml`. Use it to generate just the release notes for the version being released.

Add FreeBSD i686 and Solaris Sparc releases, as well as notes for Solaris amd64 and Dragonfly.

Set the v0.1.0 for tomorrow, as the GitHub Mac workers are currently not processing "Build and Release" workflows.