### PR TITLE
Implement v1-v2 conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "fluent-uri"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,6 +208,7 @@ name = "pgxn_meta"
 version = "0.1.0"
 dependencies = [
  "boon",
+ "email_address",
  "lexopt",
  "relative-path",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ exclude = [ ".github", ".vscode", ".gitignore", ".ci", ".pre-*.yaml"]
 
 [dependencies]
 boon = "0.6"
+email_address = "0.2.9"
 lexopt = "0.3.0"
 relative-path = { version = "1.9", features = ["serde"] }
 semver = { version = "1.0", features = ["std", "serde"] }

--- a/corpus/v1/widget.json
+++ b/corpus/v1/widget.json
@@ -24,6 +24,10 @@
       "version": "0.2.5"
     }
   },
+  "no_index": {
+    "file": ["src/file.sql"],
+    "directory": ["src/private"]
+  },
   "resources": {
     "homepage": "http://widget.example.org/"
   },

--- a/src/meta/tests.rs
+++ b/src/meta/tests.rs
@@ -5,7 +5,7 @@ use wax::Glob;
 
 #[test]
 fn test_corpus() -> Result<(), Box<dyn Error>> {
-    for v_dir in ["v2"] {
+    for v_dir in ["v1", "v2"] {
         let dir: PathBuf = [env!("CARGO_MANIFEST_DIR"), "corpus", v_dir]
             .iter()
             .collect();

--- a/src/meta/v1/mod.rs
+++ b/src/meta/v1/mod.rs
@@ -1,5 +1,548 @@
 use super::*;
 
-pub fn from_value(_: Value) -> Result<Meta, Box<dyn Error>> {
-    todo!();
+use email_address::EmailAddress;
+use serde_json::{json, Map, Value};
+use std::{error::Error, str::FromStr};
+
+/// from_value parses v1, which contains PGXN v1 metadata, into a Meta object
+/// containing valid PGXN v2 metadata.
+pub fn from_value(v1: Value) -> Result<Meta, Box<dyn Error>> {
+    // Copy common fields.
+    let mut v2 = v1_to_v2_common(&v1);
+
+    // Convert maintainer.
+    v2.insert("maintainers".to_string(), v1_to_v2_maintainers(&v1)?);
+
+    // Convert license.
+    v2.insert("license".to_string(), v1_to_v2_license(&v1)?);
+
+    // Convert provides to contents.
+    v2.insert("contents".to_string(), v1_to_v2_contents(&v1)?);
+
+    // Convert tags to classifications.
+    if let Some(val) = v1_to_v2_classifications(&v1) {
+        v2.insert("classifications".to_string(), val);
+    }
+
+    // Convert no_index to ignore.
+    if let Some(val) = v1_to_v2_ignore(&v1) {
+        v2.insert("ignore".to_string(), val);
+    }
+
+    // Convert prereqs to dependencies.
+    if let Some(val) = v1_to_v2_dependencies(&v1) {
+        v2.insert("dependencies".to_string(), val);
+    }
+
+    // resources
+    if let Some(val) = v1_to_v2_resources(&v1) {
+        v2.insert("resources".to_string(), val);
+    }
+
+    Meta::try_from(Value::Object(v2))
 }
+
+/// v1_to_v2_common sets up a new v2 map with compatible fields copied from v1
+/// and the `meta-spec` field set appropriately.
+fn v1_to_v2_common(v1: &Value) -> Map<String, Value> {
+    let mut v2 = Map::new();
+
+    // Copy fields unchanged from v1.
+    for (k1, k2) in [
+        ("name", "name"),
+        ("abstract", "abstract"),
+        ("description", "description"),
+        ("version", "version"),
+        ("generated_by", "producer"),
+    ] {
+        if let Some(v) = v1.get(k1) {
+            v2.insert(k2.to_string(), v.clone());
+        }
+    }
+
+    // Set the meta-spec.
+    v2.insert(
+        "meta-spec".to_string(),
+        json!({
+          "version": "2.0.0",
+          "url": "https://rfcs.pgxn.org/0003-meta-spec-v2.html"
+        }),
+    );
+
+    v2
+}
+
+/// v1_to_v2_maintainers clones maintainer data in v1 into the v2 format. It
+/// attempts to parse an email address from each maintainer in v1; if there is
+/// no email address, it sets `url` the value in `resources.homepage`, if
+/// present, and otherwise to `https://pgxn.org`.
+fn v1_to_v2_maintainers(v1: &Value) -> Result<Value, Box<dyn Error>> {
+    if let Some(maintainer) = v1.get("maintainer") {
+        return match maintainer {
+            Value::Array(list) => parse_v1_maintainers(v1, list),
+            Value::String(_) => {
+                let list = vec![maintainer.clone()];
+                parse_v1_maintainers(v1, &list)
+            }
+            _ => Err(Box::from(format!("Invalid v1 maintainer: {maintainer}"))),
+        };
+    }
+    Err(Box::from("maintainer property missing"))
+}
+
+/// parse_v1_maintainers parses list for a list of v1 maintainer strings and
+/// returns a list of v2 maintainer objects. For each v1 maintainer string, if
+/// contains an email address, the address and email display name will be used
+/// in for the maintainer `email` and `name` properties, respectively.
+/// Otherwise the string will be saved as the maintainer `name` and the `url`
+/// set to either the `homepage` in the `resources` object in `v1`, or else
+/// `https://pgxn.org`.
+fn parse_v1_maintainers(v1: &Value, list: &Vec<Value>) -> Result<Value, Box<dyn Error>> {
+    let mut new_list: Vec<Value> = Vec::with_capacity(list.len());
+    for v in list {
+        if let Some(str) = v.as_str() {
+            if let Ok(email) = EmailAddress::from_str(str) {
+                new_list.push(json!({
+                    "name": match email.display_part() {
+                        "" => str,
+                        d => d,
+                    },
+                    "email": email.email(),
+                }));
+            } else {
+                // No email address found. Try using resources.homepage.
+                const FALLBACK_URL: &str = "https://pgxn.org";
+                let url = match v1.get("resources") {
+                    Some(Value::Object(resources)) => match resources.get("homepage") {
+                        Some(Value::String(home)) => home.to_string(),
+                        _ => FALLBACK_URL.to_string(),
+                    },
+                    _ => FALLBACK_URL.to_string(),
+                };
+                new_list.push(json!({"name": str, "url": url}));
+            }
+        } else {
+            return Err(Box::from(format!("Invalid v1 maintainer: {v}")));
+        }
+    }
+
+    Ok(Value::Array(new_list))
+}
+
+/// v1_to_v2_license converts the value in `v1.license` into a v2 license
+/// expression:
+///
+/// *   If `v1.license` is a string, its value is converted to an SPDX license
+///     string by [license_expression_for], and returns an error if the
+///     license cannot be converted.
+/// *   If `v1.license` is an array, each value is converted to an SPDX
+///     license string by [license_expression_for], and returns an error if
+///     any license cannot be converted. Otherwise, the resulting list of
+///     license strings is `OR`ed into a license expression.
+/// *   If `v1.license` is an object, each key/value pair is converted to an
+///     SPDX license based on its key. The list of supported keys is derived
+///     from those used on PGXN, and all should be mapped to valid values. If
+///     not, an error will be returned. Otherwise, the resulting list of
+///     license strings is `OR`ed into a license expression.
+fn v1_to_v2_license(v1: &Value) -> Result<Value, Box<dyn Error>> {
+    if let Some(license) = v1.get("license") {
+        return match license {
+            Value::String(l) => {
+                if let Some(name) = license_expression_for(l.as_str()) {
+                    return Ok(Value::String(name.to_string()));
+                }
+                Err(Box::from(format!("Invalid v1 license: {license}")))
+            }
+            Value::Array(list) => {
+                // https://users.rust-lang.org/t/replace-elements-of-a-vector-as-a-function-of-previous-values/101618/6
+                let mut v = Vec::with_capacity(list.len());
+                for ln in list {
+                    match ln {
+                        Value::String(s) => {
+                            match license_expression_for(s.as_str()) {
+                                Some(name) => v.push(name.to_string()),
+                                None => return Err(Box::from(format!("Invalid v1 license: {ln}"))),
+                            };
+                        }
+                        _ => return Err(Box::from(format!("Invalid v1 license: {ln}"))),
+                    };
+                }
+                return Ok(Value::String(v.join(" OR ")));
+            }
+            Value::Object(obj) => {
+                // Map existing v1 licenses to SPDX.
+                let mut list = Vec::with_capacity(obj.len());
+                for (k, v) in obj.iter() {
+                    // These values are derived from actual releases on PGXN.
+                    // Inspected by running the following query in its
+                    // database:
+                    //
+                    // `SELECT DISTINCT jsonb(meta)->>'license' FROM distributions;`
+                    match (k.as_str(), v.as_str()) {
+                        ("PostgreSQL", _) => list.push(k.to_string()),
+                        ("Apache", _) => list.push("Apache-2.0".to_string()),
+                        ("ISC", _) => list.push(k.to_string()),
+                        ("mit", _) => list.push("MIT".to_string()),
+                        ("mozilla_2_0", _) => list.push("MPL-2.0".to_string()),
+                        ("gpl_3", _) => list.push("GPL-3.0-only".to_string()),
+                        ("BSD", _) => list.push("BSD-2-Clause".to_string()),
+                        ("BSD 2 Clause", _) => list.push("BSD-2-Clause".to_string()),
+                        (
+                            "restricted",
+                            Some("https://github.com/diffix/pg_diffix/blob/master/LICENSE.md"),
+                        ) => list.push("BUSL-1.1".to_string()),
+                        _ => return Err(Box::from(format!("Unknown v1 license: {k}: {v}"))),
+                    }
+                }
+                return Ok(Value::String(list.join(" OR ")));
+            }
+            _ => Err(Box::from(format!("Invalid v1 license: {license}"))),
+        };
+    }
+    Err(Box::from("license property missing"))
+}
+
+/// license_expression_for maps the list of v1 open source license names to
+/// valid SPDX license. The only ones not currently supported are:
+///
+/// *   `open_source`
+/// *   `restricted`
+/// *   `unrestricted`
+/// *   `ssleay` (Not used on PGXN v1)
+/// *   `unknown`: (Not used on PGXN v1)
+fn license_expression_for(name: &str) -> Option<&str> {
+    match name {
+        "agpl_3" => Some("AGPL-3.0"),
+        "apache_1_1" => Some("Apache-1.1"),
+        "apache_2_0" => Some("Apache-2.0"),
+        "artistic_1" => Some("Artistic-1.0"),
+        "artistic_2" => Some("Artistic-2.0"),
+        "bsd" => Some("BSD-3-Clause"),
+        "freebsd" => Some("BSD-2-Clause-FreeBSD"),
+        "gfdl_1_2" => Some("GFDL-1.2-or-later"),
+        "gfdl_1_3" => Some("GFDL-1.3-or-later"),
+        "gpl_1" => Some("GPL-1.0-only"),
+        "gpl_2" => Some("GPL-2.0-only"),
+        "gpl_3" => Some("GPL-3.0-only"),
+        "lgpl_2_1" => Some("LGPL-2.1"),
+        "lgpl_3_0" => Some("LGPL-3.0"),
+        "mit" => Some("MIT"),
+        "mozilla_1_0" => Some("MPL-1.0"),
+        "mozilla_1_1" => Some("MPL-1.1"),
+        "openssl" => Some("OpenSSL"),
+        "perl_5" => Some("Artistic-1.0-Perl OR GPL-1.0-or-later"),
+        "postgresql" => Some("PostgreSQL"),
+        "qpl_1_0" => Some("QPL-1.0"),
+        "sun" => Some("SISSL"),
+        "zlib" => Some("Zlib"),
+        _ => None,
+    }
+}
+
+/// v1_to_v2_contents converts a v1 `provides` object to a v2 `extensions` It
+/// sets the `sql` property to the name of the extension + `.control`, which
+/// will nearly always be correct. However, some v1 distributions may have the
+/// extension in a subdirectory. Others will not be extensions, but modules or
+/// apps, in which case the result here will be incorrect, though valid v2
+/// metadata.
+///
+/// Returns the resulting object in a valid `contents` object with
+/// `extensions` as the sole property.
+fn v1_to_v2_contents(v1: &Value) -> Result<Value, Box<dyn Error>> {
+    if let Some(provides) = v1.get("provides") {
+        // Assume everything is an extension. It's not true, but most common.
+        let mut extensions = Map::new();
+        if let Value::Object(obj) = provides {
+            for (ext, spec) in obj {
+                match spec {
+                    Value::Object(obj) => {
+                        let mut v2_spec = Map::new();
+                        // Assume control file is in the distribution root.
+                        v2_spec.insert(
+                            "control".to_string(),
+                            Value::String(ext.to_string() + ".control"),
+                        );
+
+                        // Assume file points to an SQL file (it usually does).
+                        if obj.contains_key("file") {
+                            v2_spec.insert("sql".to_string(), obj["file"].clone());
+                        } else {
+                            v2_spec.insert("sql".to_string(), Value::String("UNKNOWN".to_string()));
+                        }
+
+                        // Clone directly compatible properties.
+                        for (v2, v1) in [("doc", "docfile"), ("abstract", "abstract")] {
+                            if obj.contains_key(v1) {
+                                v2_spec.insert(v2.to_string(), obj[v1].clone());
+                            }
+                        }
+                        extensions.insert(ext.to_string(), Value::Object(v2_spec));
+                    }
+                    _ => {
+                        return Err(Box::from(format!(
+                            "Invalid v1 {:?} extension value: {spec}",
+                            ext,
+                        )))
+                    }
+                }
+            }
+        } else {
+            return Err(Box::from(format!("Invalid v1 provides value: {provides}")));
+        }
+
+        return Ok(json!({"extensions": extensions}));
+    }
+    Err(Box::from("provides property missing"))
+}
+
+/// v1_to_v2_classifications clones the tags array in v1 into an object with
+/// `tags` as the key. Returns None if v2 has no `tags` key.
+fn v1_to_v2_classifications(v1: &Value) -> Option<Value> {
+    v1.get("tags").map(|tags| json!({"tags": tags.clone()}))
+}
+
+/// v1_to_v2_ignore clones the values from the `no_index` key in v1 into a
+/// single array for the `ignore` key in a v2 object. All paths under `file`
+/// and `directory` are copied into the returned array, with any duplicates
+/// removed. Returns None if `no_index` isn't present, isn't an object, if that
+///object lacks `file` or `directory` keys, or if no values are found.
+fn v1_to_v2_ignore(v1: &Value) -> Option<Value> {
+    match v1.get("no_index") {
+        Some(Value::Object(ni)) => {
+            // Merge the file and directly arrays into a single array.
+            let mut ignore: Vec<Value> = Vec::new();
+            for k in ["file", "directory"] {
+                if let Some(Value::Array(v)) = ni.get(k) {
+                    for path in v {
+                        if !ignore.contains(path) {
+                            ignore.push(path.clone())
+                        }
+                    }
+                }
+            }
+            if ignore.is_empty() {
+                None
+            } else {
+                Some(Value::Array(ignore))
+            }
+        }
+        _ => None,
+    }
+}
+
+/// v1_to_v2_dependencies rejiggers v1 `prereqs` metadata into v1
+/// `dependencies`. Dependencies on core extensions are specified using
+/// `pkg:postgres` purls and all others are specified using `pkg:pgxn` purls.
+/// The exception is PostgreSQL dependencies, which are specified under the v1
+/// `postgres` key with the lowest version found. v2 does not currently
+/// support suggesting or recommending higher versions.
+fn v1_to_v2_dependencies(v1: &Value) -> Option<Value> {
+    use semver::Version;
+    match v1.get("prereqs") {
+        Some(Value::Object(prereqs)) => {
+            // Track Postgres version requirement. We want lowest version, so
+            // compare against unlikely v9999.
+            let max_version = Version::parse("9999.0.0").unwrap();
+            let mut pg_version = max_version.clone();
+
+            // Iterate over the v2 phases mapped to the v2 phases.
+            let mut dependencies = Map::new();
+            let mut packages = Map::new();
+            for (phase1, phase2) in [
+                ("develop", "develop"),
+                ("configure", "configure"),
+                ("build", "build"),
+                ("test", "test"),
+                ("runtime", "run"),
+            ] {
+                if let Some(Value::Object(relation)) = prereqs.get(phase1) {
+                    // We have a relation. Iterate through the list of phases.
+                    let mut phase = Map::new();
+                    for rel_name in ["requires", "recommends", "suggests", "conflicts"] {
+                        if let Some(Value::Object(spec)) = relation.get(rel_name) {
+                            // We have a phase. Iterate through its list of
+                            // key/value pairs.
+                            let mut deps = Map::new();
+                            for (name, version) in spec {
+                                let ext = name.to_lowercase();
+                                if ext == "postgresql" {
+                                    // Keep the lowest version of Postgres. v1
+                                    // doesn't support recommending a higher version.
+                                    if let Value::String(version) = version {
+                                        if let Ok(pgv) = Version::parse(version) {
+                                            if pgv < pg_version {
+                                                pg_version = pgv;
+                                            }
+                                        }
+                                    }
+                                } else {
+                                    // Insert a purl into the deps object.
+                                    // Does ext need to be URI-path encoded?
+                                    deps.insert(
+                                        format!("pkg:{}/{ext}", source_for(&ext)),
+                                        version.clone(),
+                                    );
+                                }
+                            }
+
+                            if !deps.is_empty() {
+                                phase.insert(rel_name.to_string(), Value::Object(deps));
+                            }
+                        }
+                    }
+
+                    if !phase.is_empty() {
+                        packages.insert(phase2.to_string(), Value::Object(phase));
+                    }
+                }
+            }
+
+            // Set the Postgres version if we have one.
+            if pg_version < max_version {
+                dependencies.insert("postgres".to_string(), json!({"version": pg_version}));
+            }
+
+            // If we have extensions, add them.
+            if !packages.is_empty() {
+                dependencies.insert("packages".to_string(), Value::Object(packages));
+                return Some(Value::Object(dependencies));
+            }
+
+            // Return em if we got em.
+            match dependencies.is_empty() {
+                false => Some(Value::Object(dependencies)),
+                true => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// source_for returns the purl source for ext, which must be lowercase.
+/// Return "postgres" if ext is a Postgres core extension or PL and "pgxn" for
+/// all other values.
+fn source_for(ext: &str) -> String {
+    match ext {
+        "adminpack"
+        | "amcheck"
+        | "auth_delay"
+        | "auto_explain"
+        | "basebackup_to_shell"
+        | "basic_archive"
+        | "bloom"
+        | "bool_plperl"
+        | "btree_gin"
+        | "btree_gist"
+        | "chkpass"
+        | "citext"
+        | "cube"
+        | "dblink"
+        | "dict_int"
+        | "dict_xsyn"
+        | "earthdistance"
+        | "file_fdw"
+        | "fuzzystrmatch"
+        | "hstore"
+        | "hstore_plperl"
+        | "hstore_plpython"
+        | "intagg"
+        | "intarray"
+        | "isn"
+        | "jsonb_plperl"
+        | "jsonb_plpython"
+        | "lo"
+        | "ltree"
+        | "ltree_plpython"
+        | "oid2name"
+        | "old_snapshot"
+        | "pageinspect"
+        | "passwordcheck"
+        | "pg_buffercache"
+        | "pg_freespacemap"
+        | "pg_prewarm"
+        | "pg_standby"
+        | "pg_stat_statements"
+        | "pg_surgery"
+        | "pg_trgm"
+        | "pg_visibility"
+        | "pg_walinspect"
+        | "pgcrypto"
+        | "pgrowlocks"
+        | "pgstattuple"
+        | "plperl"
+        | "plperlu"
+        | "plpgsql"
+        | "plpython"
+        | "plpythonu"
+        | "plpython2u"
+        | "plpython3u"
+        | "pltcl"
+        | "pltclu"
+        | "postgres_fdw"
+        | "seg"
+        | "sepgsql"
+        | "spi"
+        | "sslinfo"
+        | "start-scripts"
+        | "tablefunc"
+        | "tcn"
+        | "test_decoding"
+        | "tsearch2"
+        | "tsm_system_rows"
+        | "tsm_system_time"
+        | "unaccent"
+        | "uuid-ossp"
+        | "vacuumlo"
+        | "xml2" => "postgres".to_string(),
+        _ => "pgxn".to_string(),
+    }
+}
+
+/// v1_to_v2_resources copies v1 resources values to compatible v2 resources
+/// values:
+///
+/// *   v1 `homepage` is copied to v2 `homepage`
+/// *   v1 `bugtracker.web` or `bugtracker.mailto` are copied to v2 `issues`
+/// *   v1 `repository.web` or `repository.url` are copied to v2 `repository`
+///
+/// Returns `None` if v1 has no compatible resources.
+fn v1_to_v2_resources(v1: &Value) -> Option<Value> {
+    match v1.get("resources") {
+        Some(Value::Object(resources)) => {
+            let mut ret = Map::new();
+            if let Some(Value::String(home)) = resources.get("homepage") {
+                // Directly compatible value.
+                ret.insert("homepage".to_string(), json!(home));
+            }
+
+            if let Some(Value::Object(bug)) = resources.get("bugtracker") {
+                // Prefer the `web` property and fall back on `mailto`.
+                if let Some(Value::String(web)) = bug.get("web") {
+                    ret.insert("issues".to_string(), json!(web));
+                } else if let Some(Value::String(mail)) = bug.get("mailto") {
+                    ret.insert("issues".to_string(), json!(format!("mailto:{mail}")));
+                }
+            }
+
+            if let Some(Value::Object(repo)) = resources.get("repository") {
+                // Prefer the `web` property and fall back on `url`.
+                if let Some(Value::String(web)) = repo.get("web") {
+                    ret.insert("repository".to_string(), json!(web));
+                } else if let Some(Value::String(url)) = repo.get("url") {
+                    ret.insert("repository".to_string(), json!(url));
+                }
+            }
+
+            // Return the resources if we have any.
+            if ret.is_empty() {
+                None
+            } else {
+                Some(Value::Object(ret))
+            }
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/meta/v1/tests.rs
+++ b/src/meta/v1/tests.rs
@@ -1,0 +1,672 @@
+use super::*;
+
+#[test]
+fn test_v1_v2_common() {
+    let meta = json!({
+      "version": "2.0.0",
+      "url": "https://rfcs.pgxn.org/0003-meta-spec-v2.html"
+    });
+
+    for (name, input, expect) in [
+        (
+            "basics",
+            json!({"name": "pair", "version": "1.2.3", "abstract": "this and that", "description": "Howdy"}),
+            json!({"name": "pair", "version": "1.2.3", "abstract": "this and that", "description": "Howdy", "meta-spec": meta}),
+        ),
+        (
+            "name only",
+            json!({"name": "pair"}),
+            json!({"name": "pair", "meta-spec": meta}),
+        ),
+        (
+            "name and version",
+            json!({"name": "pair", "version": "1.2.3"}),
+            json!({"name": "pair", "version": "1.2.3", "meta-spec": meta}),
+        ),
+        (
+            "renamed fields",
+            json!({"generated_by": "meta_spec v0.2.0"}),
+            json!({"producer": "meta_spec v0.2.0", "meta-spec": meta}),
+        ),
+        (
+            "name and version",
+            json!({"name": "pair", "version": "1.2.3"}),
+            json!({"name": "pair", "version": "1.2.3", "meta-spec": meta}),
+        ),
+    ] {
+        let v2 = v1_to_v2_common(&input);
+        assert_eq!(expect, Value::Object(v2), "{name}");
+    }
+}
+
+#[test]
+fn test_v1_to_v2_maintainers() {
+    for (name, input, expect) in [
+        (
+            "name_and_email",
+            json!({"maintainer": "Barrack Obama <potus@example.com>"}),
+            json!([{"name": "Barrack Obama", "email": "potus@example.com"}]),
+        ),
+        (
+            "name_only",
+            json!({"maintainer": "Barrack Obama"}),
+            json!([{"name": "Barrack Obama", "url": "https://pgxn.org"}]),
+        ),
+        (
+            "name_and_homepage",
+            json!({"maintainer": "Barrack Obama", "resources": {"homepage": "https://example.com"}}),
+            json!([{"name": "Barrack Obama", "url": "https://example.com"}]),
+        ),
+        (
+            "name_and_invalid_homepage",
+            json!({"maintainer": "Barrack Obama", "resources": {"homepage": 42}}),
+            json!([{"name": "Barrack Obama", "url": "https://pgxn.org"}]),
+        ),
+        (
+            "email_only",
+            json!({"maintainer": "potus@example.com"}),
+            json!([{"name": "potus@example.com", "email": "potus@example.com"}]),
+        ),
+        (
+            "two_maintainers",
+            json!({"maintainer": [
+                "David E. Wheeler <theory@pgxn.org>",
+                "Josh Berkus <jberkus@pgxn.org>"
+            ]}),
+            json!([
+                {"name": "David E. Wheeler", "email": "theory@pgxn.org"},
+                {"name": "Josh Berkus", "email": "jberkus@pgxn.org"},
+            ]),
+        ),
+        (
+            "varying maintainer_formats",
+            json!({"maintainer": ["David E. Wheeler <theory@pgxn.org>", "Josh Berkus, Esq."]}),
+            json!([
+                {"name": "David E. Wheeler", "email": "theory@pgxn.org"},
+                {"name": "Josh Berkus, Esq.", "url": "https://pgxn.org"},
+            ]),
+        ),
+    ] {
+        match v1_to_v2_maintainers(&input) {
+            Ok(maintainers) => assert_eq!(expect, maintainers, "{name}"),
+            Err(e) => panic!("{name}: {e}"),
+        }
+    }
+}
+
+#[test]
+fn test_v1_to_v2_maintainers_errors() {
+    for (name, input, err) in [
+        (
+            "no maintainer",
+            json!({"name": "pair", "version": "1.2.4"}),
+            "maintainer property missing",
+        ),
+        (
+            "null maintainer",
+            json!({"maintainer": null}),
+            "Invalid v1 maintainer: null",
+        ),
+        (
+            "object maintainer",
+            json!({"maintainer": {"name": "hi"}}),
+            r#"Invalid v1 maintainer: {"name":"hi"}"#,
+        ),
+        (
+            "null maintainer item",
+            json!({"maintainer": [null]}),
+            "Invalid v1 maintainer: null",
+        ),
+        (
+            "true maintainer item",
+            json!({"maintainer": [true]}),
+            "Invalid v1 maintainer: true",
+        ),
+    ] {
+        match v1_to_v2_maintainers(&input) {
+            Ok(_) => panic!("{name} unexpectedly succeeded"),
+            Err(e) => assert_eq!(err, e.to_string(), "{name}"),
+        }
+    }
+}
+
+#[test]
+fn test_license_expression_for() {
+    for (v1_name, v2_name) in [
+        ("agpl_3", "AGPL-3.0"),
+        ("apache_1_1", "Apache-1.1"),
+        ("apache_2_0", "Apache-2.0"),
+        ("artistic_1", "Artistic-1.0"),
+        ("artistic_2", "Artistic-2.0"),
+        ("bsd", "BSD-3-Clause"),
+        ("freebsd", "BSD-2-Clause-FreeBSD"),
+        ("gfdl_1_2", "GFDL-1.2-or-later"),
+        ("gfdl_1_3", "GFDL-1.3-or-later"),
+        ("gpl_1", "GPL-1.0-only"),
+        ("gpl_2", "GPL-2.0-only"),
+        ("gpl_3", "GPL-3.0-only"),
+        ("lgpl_2_1", "LGPL-2.1"),
+        ("lgpl_3_0", "LGPL-3.0"),
+        ("mit", "MIT"),
+        ("mozilla_1_0", "MPL-1.0"),
+        ("mozilla_1_1", "MPL-1.1"),
+        ("openssl", "OpenSSL"),
+        ("perl_5", "Artistic-1.0-Perl OR GPL-1.0-or-later"),
+        ("postgresql", "PostgreSQL"),
+        ("qpl_1_0", "QPL-1.0"),
+        ("sun", "SISSL"),
+        ("zlib", "Zlib"),
+    ] {
+        let v2 = license_expression_for(v1_name);
+        assert_eq!(Some(v2_name), v2);
+    }
+
+    // V1 License not included in the SPDX license list.
+    for v1_name in [
+        "ssleay",
+        "open_source",
+        "restricted",
+        "unrestricted",
+        "unknown",
+    ] {
+        assert_eq!(None, license_expression_for(v1_name));
+    }
+}
+
+#[test]
+fn test_v1_v2_licenses() {
+    for (name, input, expect) in [
+        (
+            "apache_2_0",
+            json!({"license": "apache_2_0"}),
+            json!("Apache-2.0"),
+        ),
+        (
+            "perl_5",
+            json!({"license": "perl_5"}),
+            json!("Artistic-1.0-Perl OR GPL-1.0-or-later"),
+        ),
+        (
+            "array",
+            json!({"license": ["apache_2_0", "perl_5"]}),
+            json!("Apache-2.0 OR Artistic-1.0-Perl OR GPL-1.0-or-later"),
+        ),
+        (
+            "another",
+            json!({"license": ["mit", "postgresql"]}),
+            json!("MIT OR PostgreSQL"),
+        ),
+        (
+            "object",
+            json!({"license": {"PostgreSQL": "https://www.postgresql.org/about/licence"}}),
+            json!("PostgreSQL"),
+        ),
+        (
+            "object_multiple",
+            json!({"license": {
+                "PostgreSQL": "https://www.postgresql.org/about/licence",
+                "Apache": "http://www.apache.org/licenses/LICENSE-2.0",
+            }}),
+            json!("Apache-2.0 OR PostgreSQL"),
+        ),
+        (
+            "object_all_others",
+            json!({"license": {
+                "restricted": "https://github.com/diffix/pg_diffix/blob/master/LICENSE.md",
+                "ISC": "http://www.opensource.org/licenses/ISC",
+                "mit": "http://en.wikipedia.org/wiki/MIT_License",
+                "mozilla_2_0": "https://www.mozilla.org/en-US/MPL/2.0/",
+                "gpl_3": "https://www.gnu.org/licenses/gpl-3.0.en.html",
+                "BSD 2 Clause": "http://opensource.org/licenses/bsd-license.php",
+                "BSD": "http://www.opensource.org/licenses/bsd-license.html"
+            }}),
+            json!(
+                "BSD-2-Clause OR BSD-2-Clause OR ISC OR GPL-3.0-only OR MIT OR MPL-2.0 OR BUSL-1.1"
+            ),
+        ),
+    ] {
+        match v1_to_v2_license(&input) {
+            Ok(lic) => assert_eq!(expect, lic, "{name}"),
+            Err(e) => panic!("{name}: {e}"),
+        }
+    }
+}
+
+#[test]
+fn test_v1_v2_licenses_error() {
+    for (name, input, err) in [
+        (
+            "unknown string",
+            json!({"license": "nonesuch"}),
+            "Invalid v1 license: \"nonesuch\"",
+        ),
+        (
+            "unknown array",
+            json!({"license": ["nonesuch"]}),
+            "Invalid v1 license: \"nonesuch\"",
+        ),
+        (
+            "array non-string item",
+            json!({"license": [{"x": "y"}]}),
+            "Invalid v1 license: {\"x\":\"y\"}",
+        ),
+        (
+            "unknown object",
+            json!({"license": {"nonesuch": "http://example.com"}}),
+            "Unknown v1 license: nonesuch: \"http://example.com\"",
+        ),
+        ("number", json!({"license": 42}), "Invalid v1 license: 42"),
+        ("null", json!({"license": null}), "Invalid v1 license: null"),
+        ("nonexistent", json!({}), "license property missing"),
+    ] {
+        match v1_to_v2_license(&input) {
+            Ok(_) => panic!("{name} unexpectedly succeeded"),
+            Err(e) => assert_eq!(err, e.to_string(), "{name}"),
+        }
+    }
+}
+
+#[test]
+fn test_v1_v2_contents() {
+    for (name, input, expect) in [
+        (
+            "simple",
+            json!({"widget": {
+                "file": "sql/widget.sql.in",
+                "version": "0.2.5",
+            }}),
+            json!({"widget": {
+                "control": "widget.control",
+                "sql": "sql/widget.sql.in",
+            }}),
+        ),
+        (
+            "full",
+            json!({"pair": {
+                "abstract": "A key/value pair data type",
+                "file": "sql/pair.sql",
+                "docfile": "doc/pair.md",
+                "version": "0.1.0"
+            }}),
+            json!({"pair": {
+                "control": "pair.control",
+                "sql": "sql/pair.sql",
+                "abstract": "A key/value pair data type",
+                "doc": "doc/pair.md",
+            }}),
+        ),
+        (
+            "no file",
+            json!({"thing": {}}),
+            json!({"thing": {
+                "control": "thing.control",
+                "sql": "UNKNOWN",
+            }}),
+        ),
+    ] {
+        let input = json!({"provides": input});
+        let expect = json!({"extensions": expect});
+        match v1_to_v2_contents(&input) {
+            Ok(ext) => assert_eq!(expect, ext, "{name}"),
+            Err(e) => panic!("{name}: {e}"),
+        }
+    }
+}
+
+#[test]
+fn test_v1_v2_contents_err() {
+    for (name, input, err) in [
+        ("no provides", json!({}), "provides property missing"),
+        (
+            "provides null",
+            json!({"provides": null}),
+            "Invalid v1 provides value: null",
+        ),
+        (
+            "extension not object",
+            json!({"provides": {"foo": []}}),
+            "Invalid v1 \"foo\" extension value: []",
+        ),
+    ] {
+        match v1_to_v2_contents(&input) {
+            Ok(_) => panic!("{name} unexpectedly succeeded"),
+            Err(e) => assert_eq!(err, e.to_string(), "{name}"),
+        }
+    }
+}
+
+#[test]
+fn test_v1_v2_classifications() {
+    for (name, input, expect) in [
+        (
+            "one tag",
+            json!({"tags": ["xxx"]}),
+            Some(json!({"tags": ["xxx"]})),
+        ),
+        (
+            "tags",
+            json!({"tags": ["xxx", "yyy"], "name": "pair"}),
+            Some(json!({"tags": ["xxx", "yyy"]})),
+        ),
+        ("no tags", json!({"name": "pair"}), None),
+        (
+            "null tags",
+            json!({"tags": null, "name": "pair"}),
+            Some(json!({"tags": null})),
+        ),
+    ] {
+        assert_eq!(expect, v1_to_v2_classifications(&input), "{name}")
+    }
+}
+
+#[test]
+fn test_v1_v2_ignore() {
+    for (name, input, expect) in [
+        (
+            "file",
+            json!({"no_index": {"file": ["xxx"]}}),
+            Some(json!(["xxx"])),
+        ),
+        (
+            "two files",
+            json!({"no_index": {"file": ["xxx", "yyy"]}}),
+            Some(json!(["xxx", "yyy"])),
+        ),
+        (
+            "files and directories",
+            json!({"no_index": {"file": ["xxx", "yyy"], "directory": ["src/private"]}}),
+            Some(json!(["xxx", "yyy", "src/private"])),
+        ),
+        (
+            "dedup",
+            json!({"no_index": {"file": ["xxx", "yyy"], "directory": ["src/private", "xxx"]}}),
+            Some(json!(["xxx", "yyy", "src/private"])),
+        ),
+        (
+            "ignore other keys",
+            json!({"no_index": {"file": ["xxx"], "lol": ["its me"]}}),
+            Some(json!(["xxx"])),
+        ),
+        ("no no_index", json!({"name": "pair"}), None),
+        ("null no_index", json!({"no_index": null}), None),
+        ("string no_index", json!({"no_index": "hi"}), None),
+        ("object no_index", json!({"no_index": {}}), None),
+        (
+            "empty values",
+            json!({"no_index": {"file": [], "directory": []}}),
+            None,
+        ),
+    ] {
+        assert_eq!(expect, v1_to_v2_ignore(&input), "{name}")
+    }
+}
+
+#[test]
+fn test_v1_v2_dependencies() {
+    for (name, input, expect) in [
+        (
+            "runtime requires",
+            json!({"prereqs": {"runtime": {"requires": {"v8": "1.2.0"}}}}),
+            Some(json!({"packages": {"run": {"requires": {"pkg:pgxn/v8": "1.2.0"}}}})),
+        ),
+        (
+            "build core and pgxn",
+            json!({"prereqs": {"build": {"requires": {"pgtap": "1.3.0", "plpgsql": "12.0.0"}}}}),
+            Some(json!({"packages": {"build": {"requires": {
+                    "pkg:pgxn/pgtap": "1.3.0",
+                    "pkg:postgres/plpgsql": "12.0.0",
+            }}}})),
+        ),
+        (
+            "postgres requires",
+            json!({"prereqs": {"runtime": {"requires": {"PostgreSQL": "12.0.0"}}}}),
+            Some(json!({"postgres": {"version": "12.0.0"}})),
+        ),
+        (
+            "dvelop conflicts",
+            json!({"prereqs": {"develop": {"conflicts": {"v8": "1.2.0"}}}}),
+            Some(json!({"packages": {"develop": {"conflicts": {"pkg:pgxn/v8": "1.2.0"}}}})),
+        ),
+        (
+            "lots of stuff",
+            json!({"prereqs": {
+                "runtime": {
+                    "requires": {
+                        "PostgreSQL": "8.0.0",
+                        "PostGIS": "1.5.0"
+                    },
+                    "recommends": {
+                        "PostgreSQL": "8.4.0"
+                    },
+                    "suggests": {
+                        "sha1": 0
+                    }
+                },
+                "build": {
+                    "requires": {
+                        "prefix": 0
+                    }
+                },
+                "test": {
+                    "recommends": {
+                        "pgTAP": 0
+                    }
+                },
+            }}),
+            Some(json!({
+                "postgres": {"version": "8.0.0"},
+                "packages": {
+                    "run": {
+                        "requires": {"pkg:pgxn/postgis": "1.5.0"},
+                        "suggests": {"pkg:pgxn/sha1": 0},
+                    },
+                    "build": {
+                        "requires": {"pkg:pgxn/prefix": 0},
+                    },
+                    "test": {
+                        "recommends": {"pkg:pgxn/pgtap": 0},
+                    }
+                }
+            })),
+        ),
+        (
+            "invalid postgres requires",
+            json!({"prereqs": {"runtime": {"requires": {"PostgreSQL": "nope"}}}}),
+            None,
+        ),
+        (
+            "null postgres requires",
+            json!({"prereqs": {"runtime": {"requires": {"PostgreSQL": null}}}}),
+            None,
+        ),
+        (
+            "unknown phase",
+            json!({"prereqs": {"lol": {"requires": {"isn": 0}}}}),
+            None,
+        ),
+        ("null prereqs", json!({"prereqs": null}), None),
+        ("array prereqs", json!({"prereqs": []}), None),
+        ("number prereqs", json!({"prereqs": 42}), None),
+        ("string prereqs", json!({"prereqs": "hi"}), None),
+    ] {
+        assert_eq!(expect, v1_to_v2_dependencies(&input), "{name}")
+    }
+}
+
+#[test]
+fn test_source_for() {
+    for name in [
+        "adminpack",
+        "amcheck",
+        "auth_delay",
+        "auto_explain",
+        "basebackup_to_shell",
+        "basic_archive",
+        "bloom",
+        "bool_plperl",
+        "btree_gin",
+        "btree_gist",
+        "chkpass",
+        "citext",
+        "cube",
+        "dblink",
+        "dict_int",
+        "dict_xsyn",
+        "earthdistance",
+        "file_fdw",
+        "fuzzystrmatch",
+        "hstore",
+        "hstore_plperl",
+        "hstore_plpython",
+        "intagg",
+        "intarray",
+        "isn",
+        "jsonb_plperl",
+        "jsonb_plpython",
+        "lo",
+        "ltree",
+        "ltree_plpython",
+        "oid2name",
+        "old_snapshot",
+        "pageinspect",
+        "passwordcheck",
+        "pg_buffercache",
+        "pg_freespacemap",
+        "pg_prewarm",
+        "pg_standby",
+        "pg_stat_statements",
+        "pg_surgery",
+        "pg_trgm",
+        "pg_visibility",
+        "pg_walinspect",
+        "pgcrypto",
+        "pgrowlocks",
+        "pgstattuple",
+        "plperl",
+        "plperlu",
+        "plpgsql",
+        "plpython",
+        "plpythonu",
+        "plpython2u",
+        "plpython3u",
+        "pltcl",
+        "pltclu",
+        "postgres_fdw",
+        "seg",
+        "sepgsql",
+        "spi",
+        "sslinfo",
+        "start-scripts",
+        "tablefunc",
+        "tcn",
+        "test_decoding",
+        "tsearch2",
+        "tsm_system_rows",
+        "tsm_system_time",
+        "unaccent",
+        "uuid-ossp",
+        "vacuumlo",
+        "xml2",
+    ] {
+        assert_eq!("postgres".to_string(), source_for(name), "{name}")
+    }
+
+    // SELECT DISTINCT jsonb_object_keys(jsonb_path_query(jsonb(meta), '$.prereqs.*.*')) FROM distributions;
+    for name in [
+        "berkeleydb",
+        "v8",
+        "lambda",
+        "vectorscale",
+        "pg_partman",
+        "ddlx",
+        "pgtap",
+        "pgtap",
+        "pgvector",
+        "trunklet",
+        "variant",
+        "pg_jobmon",
+        "pg_cron",
+        "columnar",
+        "bignum",
+        "oracle",
+        "pgmq",
+        "cat_tools",
+        "plproxy",
+        "pg_readme",
+        "postgis",
+        "python",
+        "pgbitmap",
+        "pg_utility_trigger_functions",
+    ] {
+        assert_eq!("pgxn".to_string(), source_for(name), "{name}")
+    }
+}
+
+#[test]
+fn test_v1_v2_resources() {
+    for (name, input, expect) in [
+        ("no resources", json!({"name": "hi"}), None),
+        ("empty resources", json!({"resources": {}}), None),
+        ("null resources", json!({"resources": null}), None),
+        ("string resources", json!({"resources": "hi"}), None),
+        ("number resources", json!({"resources": 42}), None),
+        ("bool resources", json!({"resources": true}), None),
+        (
+            "homepage",
+            json!({"name": "hi", "resources": {"homepage": "https://pgtap.org"}}),
+            Some(json!({"homepage": "https://pgtap.org"})),
+        ),
+        (
+            "bugtracker web",
+            json!({"resources": {"bugtracker": {
+                "web": "https://github.org/pgxn/meta/issues",
+                "mailto": "hi@example.com",
+            }}}),
+            Some(json!({"issues": "https://github.org/pgxn/meta/issues"})),
+        ),
+        (
+            "bugtracker mailto",
+            json!({"resources": {"bugtracker": {
+                "mailto": "hi@example.com",
+            }}}),
+            Some(json!({"issues": "mailto:hi@example.com"})),
+        ),
+        (
+            "repo web",
+            json!({"resources": {"repository": {
+                "web": "https://github.org/pgxn/meta",
+                "url": "git@github.com:pgxn/meta.git",
+            }}}),
+            Some(json!({"repository": "https://github.org/pgxn/meta"})),
+        ),
+        (
+            "repo url",
+            json!({"resources": {"repository": {
+                "url": "git@github.com:pgxn/meta.git",
+            }}}),
+            Some(json!({"repository": "git@github.com:pgxn/meta.git"})),
+        ),
+    ] {
+        assert_eq!(expect, v1_to_v2_resources(&input), "{name}")
+    }
+}
+
+#[test]
+fn test_from_value() -> Result<(), Box<dyn Error>> {
+    use wax::Glob;
+    let dir: PathBuf = [env!("CARGO_MANIFEST_DIR"), "corpus", "v1"]
+        .iter()
+        .collect();
+    let glob = Glob::new("*.json")?;
+
+    for path in glob.walk(dir) {
+        let path = path?.into_path();
+        let meta: Value = serde_json::from_reader(File::open(&path)?)?;
+        if let Err(e) = from_value(meta) {
+            panic!("{:?} failed: {e}", path.file_name().unwrap());
+        }
+        println!("Example {:?} ok", path.file_name().unwrap());
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
In the pgxn_meta::meta::v1 module, implement the logic necessary to convert PGXN v1 metadata to v2. This includes:

*   Directly copying fields unchanged between v1 and v2
*   Setting the `meta-spec` field for v2
*   Converting maintainers and capturing email address where possible, falling back on `resources.homepage` or a static placeholder URL.
*   Converting licenses to valid SPDX license expressions, mapping all known licenses as closely as possible.
*   Converting `provides` to `contents`, assuming each extension name has a control file at the root of the distribution. This will not always be the case, but we'll later add the ability to merge additional metadata to patch those cases.
*   Copying `tags` to `classifications.tags`
*   Merging `no_index.file` and `no_index.directory` into a single `ignore` list
*   Converting `prereqs` to `dependencies`, complete with Postgres version extraction (preserving the lowest version found), and separating Postgres core packages (`pkg:postgres`) from all others, which are assumed to be PGXN packages (`pkg:pgxn).
*   Converting v1 `resources` to v2 `resources`, preferring to preserve `bugtracker.web` and falling back on `bugtracker.mailto` for `issues`; and preferring `repository.web` to `repository.url` for `repository`.

Includes unit tests for each of these cases, and adds the v1 corpus to the test that the various `Meta::try_from` constructors use the conversion and the results are valid v2 metadata.