### PR TITLE
Add TryFrom multiple JSON values

### DIFF
--- a/.ci/test-cover
+++ b/.ci/test-cover
@@ -18,6 +18,7 @@ grcov "${DESTDIR}" \
     --ignore '**/tests/**' \
     --ignore 'build.rs' \
     --excl-start '#(\[cfg\(test\)\]|\[test\])' \
+    --excl-line 'unreachable\!\(\)' \
     --llvm \
     --binary-path "target/debug/" \
     -s . \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "json-patch"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b1fb8864823fad91877e6caea0baca82e49e8db50f8e5c9f9a453e27d3330fc"
+dependencies = [
+ "jsonptr",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "jsonptr"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c6e529149475ca0b2820835d3dce8fcc41c6b943ca608d32f35b449255e4627"
+dependencies = [
+ "fluent-uri",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "lexopt"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +243,7 @@ dependencies = [
  "assert-json-diff",
  "boon",
  "email_address",
+ "json-patch",
  "lexopt",
  "relative-path",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ exclude = [ ".github", ".vscode", ".gitignore", ".ci", ".pre-*.yaml"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-assert-json-diff = "2.0.2"
 boon = "0.6"
 email_address = "0.2.9"
+json-patch = "2.0.0"
 lexopt = "0.3.0"
 relative-path = { version = "1.9", features = ["serde"] }
 semver = { version = "1.0", features = ["std", "serde"] }
@@ -31,3 +31,4 @@ wax = "0.6.0"
 serde_json = "1.0"
 
 [dev-dependencies]
+assert-json-diff = "2.0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ assert!(validator.validate(&meta).is_ok());
 
 */
 
+mod util;
 mod valid;
 pub use valid::{ValidationError, Validator};
 mod meta;

--- a/src/meta/tests.rs
+++ b/src/meta/tests.rs
@@ -105,3 +105,316 @@ fn test_bad_corpus() -> Result<(), Box<dyn Error>> {
 
     Ok(())
 }
+
+#[test]
+fn test_try_merge_v1() -> Result<(), Box<dyn Error>> {
+    // Load a v1 META file.
+    let dir: PathBuf = [env!("CARGO_MANIFEST_DIR"), "corpus"].iter().collect();
+    let widget_file = dir.join("v1").join("widget.json");
+    let contents: Value = serde_json::from_reader(File::open(&widget_file)?)?;
+
+    // expect maps a JSON pointer to an expected value.
+    for (name, patches, expect) in [
+        (
+            "license",
+            vec![json!({"license": "MIT"})],
+            json!({"/license": "MIT"}),
+        ),
+        (
+            "tle",
+            vec![json!({"contents": {"extensions": {"widget": {"tle": true}}}})],
+            json!({"/contents/extensions/widget": {
+                "control": "widget.control",
+                "sql": "sql/widget.sql.in",
+                "tle": true,
+            }}),
+        ),
+        (
+            "categories",
+            vec![json!({"classifications": {"categories": ["Analytics", "Connectors"]}})],
+            json!({"/classifications/categories": ["Analytics", "Connectors"]}),
+        ),
+        (
+            "tags",
+            vec![json!({"classifications": {"tags": ["hi", "go", "ick"]}})],
+            json!({"/classifications/tags": ["hi", "go", "ick"]}),
+        ),
+        (
+            "resources",
+            vec![json!({"resources": {
+                "issues": "https://example.com/issues",
+                "repository": "https://example.com/repo",
+            }})],
+            json!({"/resources": {
+                "homepage": "http://widget.example.org/",
+                "issues": "https://example.com/issues",
+                "repository": "https://example.com/repo",
+            }}),
+        ),
+        (
+            "delete packages",
+            vec![json!({"dependencies": {"packages": null}})],
+            json!({"/dependencies": {"postgres": { "version": "8.0.0" }}}),
+        ),
+    ] {
+        run_merge_case(name, &contents, patches.as_slice(), &expect)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_try_merge_v2() -> Result<(), Box<dyn Error>> {
+    // Load a v2 META file.
+    let dir: PathBuf = [env!("CARGO_MANIFEST_DIR"), "corpus"].iter().collect();
+    let widget_file = dir.join("v2").join("minimal.json");
+    let contents: Value = serde_json::from_reader(File::open(&widget_file)?)?;
+
+    // expect maps a JSON pointer to an expected value.
+    for (name, patches, expect) in [
+        (
+            "license",
+            vec![json!({"license": "MIT"})],
+            json!({"/license": "MIT"}),
+        ),
+        (
+            "tle",
+            vec![json!({"contents": {"extensions": {"pair": {"tle": true}}}})],
+            json!({"/contents/extensions/pair": {
+                "sql": "sql/pair.sql",
+                "control": "pair.control",
+                "tle": true,
+            }}),
+        ),
+        (
+            "multiple patches",
+            vec![
+                json!({"license": "MIT"}),
+                json!({"classifications": {"categories": ["Analytics", "Connectors"]}}),
+            ],
+            json!({
+                "/license": "MIT",
+                "/classifications/categories": ["Analytics", "Connectors"],
+            }),
+        ),
+    ] {
+        run_merge_case(name, &contents, patches.as_slice(), &expect)?;
+    }
+
+    Ok(())
+}
+
+fn run_merge_case(
+    name: &str,
+    orig: &Value,
+    patches: &[Value],
+    expect: &Value,
+) -> Result<(), Box<dyn Error>> {
+    let mut meta = vec![orig];
+    for p in patches {
+        meta.push(p);
+    }
+    match Meta::try_from(meta.as_slice()) {
+        Err(e) => panic!("patching {name} failed: {e}"),
+        Ok(m) => {
+            // Convert the Meta object to JSON.
+            let output: Result<Value, Box<dyn Error>> = m.try_into();
+            match output {
+                Err(e) => panic!("{name} serialization failed: {e}"),
+                Ok(val) => {
+                    // Compare expected values at pointers.
+                    for (p, v) in expect.as_object().unwrap() {
+                        assert_eq!(v, val.pointer(p).unwrap())
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_try_merge_err() -> Result<(), Box<dyn Error>> {
+    // Load invalid meta.
+    let dir: PathBuf = [env!("CARGO_MANIFEST_DIR"), "corpus"].iter().collect();
+    let widget_file = dir.join("invalid.json");
+    let invalid: Value = serde_json::from_reader(File::open(&widget_file)?)?;
+
+    let empty = json!({});
+    let bad_version = json!({"meta-spec": { "version": null}});
+
+    for (name, arg, err) in [
+        ("no meta", vec![], "meta contains no values"),
+        (
+            "no version",
+            vec![&empty],
+            "No spec version found in first meta value",
+        ),
+        (
+            "bad version",
+            vec![&bad_version],
+            "No spec version found in first meta value",
+        ),
+        (
+            "invalid",
+            vec![&invalid],
+            "jsonschema validation failed with https://pgxn.org/meta/v2/distribution.schema.json#\n- at '': missing properties 'version'",
+        ),
+    ] {
+        match Meta::try_from(arg.as_slice()) {
+            Ok(_) => panic!("patching {name} unexpectedly succeeded"),
+            Err(e) => assert_eq!(err, e.to_string(), "{name}"),
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_try_merge_partman() -> Result<(), Box<dyn Error>> {
+    // Test the real-world pg_partman JSON with a patch to build the expected
+    // v2 JSON. First, load the original metadata.
+    let original_meta = json!({
+        "name": "pg_partman",
+        "abstract": "Extension to manage partitioned tables by time or ID",
+        "version": "5.1.0",
+        "maintainer": [
+            "Keith Fiske <keith@keithf4.com>"
+        ],
+        "license": "postgresql",
+        "generated_by": "Keith Fiske",
+        "release_status": "stable",
+        "prereqs": {
+            "runtime": {
+                "requires": {
+                    "PostgreSQL": "14.0"
+                },
+                "recommends": {
+                    "pg_jobmon": "1.4.1"
+                }
+            }
+        },
+        "provides": {
+            "pg_partman": {
+                "file": "sql/pg_partman--5.1.0.sql",
+                "docfile": "doc/pg_partman.md",
+                "version": "5.1.0",
+                "abstract": "Extension to manage partitioned tables by time or ID"
+            }
+        },
+        "resources": {
+            "bugtracker": {
+                "web": "https://github.com/pgpartman/pg_partman/issues"
+            },
+            "repository": {
+                "url": "git://github.com/pgpartman/pg_partman.git" ,
+                "web": "https://github.com/pgpartman/pg_partman",
+                "type": "git"
+            }
+        },
+        "meta-spec": {
+          "version": "1.0.0",
+          "url": "http://pgxn.org/meta/spec.txt"
+        },
+        "tags": [
+            "partition",
+            "partitions",
+            "partitioning",
+            "table",
+            "tables",
+            "bgw",
+            "background worker",
+            "custom background worker"
+        ]
+    });
+
+    // Load expected metadata.
+    let dir: PathBuf = [env!("CARGO_MANIFEST_DIR"), "corpus", "v2"]
+        .iter()
+        .collect();
+    let widget_file = dir.join("pg_partman.json");
+    let expect_meta: Value = serde_json::from_reader(File::open(&widget_file)?)?;
+
+    // Create the patch.
+    let patch = json!({
+        "contents": {
+          "extensions": {
+            "pg_partman": {
+              "sql": "sql/types/types.sql",
+            }
+          },
+          "modules": {
+            "pg_partman_bgw": {
+              "type": "bgw",
+              "lib": "src/pg_partman_bgw",
+              "preload": "server"
+            }
+          },
+          "apps": {
+            "check_unique_constraint": {
+              "lang": "python",
+              "bin": "bin/common/check_unique_constraint.py",
+              "abstract": "Check that all rows in a partition set are unique for the given columns"
+            },
+            "dump_partition": {
+              "lang": "python",
+              "bin": "bin/common/dump_partition.py",
+              "abstract": "Dump out and then drop all tables contained in a schema."
+            },
+            "vacuum_maintenance": {
+              "lang": "python",
+              "bin": "bin/common/vacuum_maintenance.py",
+              "abstract": "Performing vacuum maintenance on to avoid excess vacuuming and transaction id wraparound issues"
+            }
+          }
+        },
+        "producer": "David E. Wheeler",
+        "resources": {
+          "issues": "https://github.com/theory/pg-envvar/issues/",
+          "repository": "https://github.com/theory/pg-envvar/",
+          "badges": [
+            {
+              "alt": "CI Status",
+              "src": "https://github.com/theory/pg-envvar/actions/workflows/ci.yml/badge.svg",
+              "url": "https://github.com/theory/pg-envvar/actions/workflows/ci.yml"
+            }
+          ]
+        },
+        "dependencies": {
+          "postgres": {
+            "version": "14.0"
+          },
+          "packages": {
+            "run": {
+              "requires": {
+                "pkg:generic/python": "2.0",
+                "pkg:pypi/psycopg2": 0
+              },
+            }
+          }
+        },
+        "classifications": {
+          "categories": ["Orchestration"],
+        },
+    });
+
+    // Apply the patch.
+    let meta = [&original_meta, &patch];
+    match Meta::try_from(&meta[..]) {
+        Err(e) => panic!("patching part man failed: {e}"),
+        Ok(m) => {
+            // Convert the Meta object to JSON.
+            let output: Result<Value, Box<dyn Error>> = m.try_into();
+            match output {
+                Err(e) => panic!("partman serialization failed: {e}"),
+                Ok(val) => {
+                    // Compare to expected.
+                    assert_json_diff::assert_json_eq!(&expect_meta, &val);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,76 @@
+use serde_json::Value;
+
+// get_version returns the major version from the value stored in
+// `meta-spec.version` in `meta`. Returns None if the field does not exist or
+// does not contain a valid version (either 1 or 2).
+pub fn get_version(meta: &Value) -> Option<u8> {
+    let v = meta.get("meta-spec")?.get("version")?.as_str()?;
+    if v.len() < 2 {
+        return None;
+    }
+    match &v[0..2] {
+        "1." => Some(1),
+        "2." => Some(2),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_get_version() {
+        for (name, meta, expect) in [
+            (
+                "1.0.0",
+                json!({"meta-spec": { "version": "1.0.0"}}),
+                Some(1),
+            ),
+            (
+                "1.0.1",
+                json!({"meta-spec": { "version": "1.0.1"}}),
+                Some(1),
+            ),
+            (
+                "1.1.0",
+                json!({"meta-spec": { "version": "1.1.0"}}),
+                Some(1),
+            ),
+            ("1.", json!({"meta-spec": { "version": "1."}}), Some(1)),
+            (
+                "2.0.0",
+                json!({"meta-spec": { "version": "2.0.0"}}),
+                Some(2),
+            ),
+            (
+                "2.0.1",
+                json!({"meta-spec": { "version": "2.0.1"}}),
+                Some(2),
+            ),
+            (
+                "2.1.0",
+                json!({"meta-spec": { "version": "2.1.0"}}),
+                Some(2),
+            ),
+            ("2.", json!({"meta-spec": { "version": "2."}}), Some(2)),
+            ("3.", json!({"meta-spec": { "version": "3."}}), None),
+            ("3.0.0", json!({"meta-spec": { "version": "3.0.0"}}), None),
+            ("9.0.0", json!({"meta-spec": { "version": "9.0.0"}}), None),
+            ("too short", json!({"meta-spec": { "version": "1"}}), None),
+            ("empty string", json!({"meta-spec": { "version": ""}}), None),
+            ("null", json!({"meta-spec": { "version": null}}), None),
+            ("bool", json!({"meta-spec": { "version": true}}), None),
+            ("number", json!({"meta-spec": { "version": 1}}), None),
+            ("object", json!({"meta-spec": { "version": {}}}), None),
+            ("array", json!({"meta-spec": { "version": []}}), None),
+            ("no version", json!({"meta-spec": {}}), None),
+            ("meta-spec array", json!({"meta-spec": [1]}), None),
+            ("no meta-spec", json!({}), None),
+            ("root array", json!([1]), None),
+        ] {
+            assert_eq!(expect, get_version(&meta), "{name}")
+        }
+    }
+}

--- a/src/valid/mod.rs
+++ b/src/valid/mod.rs
@@ -4,6 +4,8 @@ use std::{error::Error, fmt};
 use boon::{Compiler, Schemas};
 use serde_json::Value;
 
+use crate::util;
+
 // Export compiler publicly only for tests.
 #[cfg(test)]
 pub mod compiler;
@@ -64,22 +66,7 @@ impl Validator {
     /// for validation. Returns a the Meta spec version on success and a
     /// validation error on failure.
     pub fn validate<'a>(&'a mut self, meta: &'a Value) -> Result<u8, Box<dyn Error + '_>> {
-        let map = meta.as_object().ok_or(ValidationError::UnknownSpec)?;
-        let version = map
-            .get("meta-spec")
-            .ok_or(ValidationError::UnknownSpec)?
-            .as_object()
-            .ok_or(ValidationError::UnknownSpec)?
-            .get("version")
-            .ok_or(ValidationError::UnknownSpec)?
-            .as_str()
-            .ok_or(ValidationError::UnknownSpec)?;
-
-        let v = match &version[0..2] {
-            "1." => 1,
-            "2." => 2,
-            _ => return Err(Box::new(ValidationError::UnknownSpec)),
-        };
+        let v = util::get_version(meta).ok_or(ValidationError::UnknownSpec)?;
         let id = format!("{SCHEMA_BASE}{v}/distribution.schema.json");
 
         let compiler = &mut self.compiler;


### PR DESCRIPTION
Assume the first value is the primary metadata, generally included in a distribution. Merge subsequent values into that first value via the [RFC 7396] merge pattern. This is ideal for changing objects, but arrays must be replaced in their entirety. When all patches have been applied, then validate the final document and deserialize it into a Meta object.Since

In order to convert v1 metadata to a JSON value, refactor `src/meta/v1/mod.rs` by adding `to_v2()`, which returns a JSON Value, and use it in the existing `from_value()` function. While at it, use a reference to the v1 metadata in `to_v2()`, since its data is copied to the v2 result.

Use the json_merge crate to do the merging. The [implementation] is dead simple, so it's kind of overkill, but it's nice to have the crate on hand in cas we later decide to support the [JSON Patch] format, as well.

The new trait implementation, `impl TryFrom<&[&Value]> for Meta`, needs to fetch the meta spec version from the first Value passed to it. So extract that pattern from `src/valid/mod.rs` and move it to a new `util` module that's private to the crate. Add a slew of tests for its behavior, as well.

Add tests to ensure full coverage and proper patch behavior for v1 and v2 patches, as well as a real-world fairly complicated example patching the pg_partman v2 metadata to the anticipated v2 metadata.

Since the util function, `get_version`, only ever returns 1 or 2, in the branching on its value panic with `unreachable!()` for any other value. This should only happen in some far off future where a v3 is added. To keep test coverage at 100%, tweak the coverage reporting to ignore lines that use `unreachable!()`, which are untestable.

  [implementation]: https://github.com/idubrov/json-patch/blob/v2.0.0/src/lib.rs#L660-L677
  [JSON Patch]: https://docs.rs/json-patch/latest/json_patch/fn.patch.html