### PR TITLE
Add missing custom field handling

### DIFF
--- a/corpus/v2/custom-fields.json
+++ b/corpus/v2/custom-fields.json
@@ -36,7 +36,7 @@
         "alt": "CI Status",
         "src": "https://github.com/example/pg-widget/actions/workflows/ci.yml/badge.svg",
         "url": "https://github.com/example/pg-widget/actions/workflows/ci.yml",
-        "x_updated_every": "1h"
+        "x_updated_every": { "1h": true, "1w": false }
       }
     ]
   },
@@ -87,5 +87,8 @@
     "tags": ["variadic function"],
     "x_ui_related": true
   },
-  "meta-spec": { "version": "2.0.0" }
+  "meta-spec": {
+    "version": "2.0.0",
+    "x_hello": [1, 2, 3]
+  }
 }

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -13,7 +13,7 @@ use std::{collections::HashMap, error::Error, fs::File, path::PathBuf};
 use crate::util;
 use relative_path::RelativePathBuf;
 use semver::Version;
-use serde::{ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 
 mod v1;
@@ -25,6 +25,9 @@ pub struct Spec {
     version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     url: Option<String>,
+    #[serde(flatten)]
+    #[serde(deserialize_with = "deserialize_custom_properties")]
+    custom_props: HashMap<String, Value>,
 }
 
 /// Maintainer represents an object in the list of `maintainers` in [`Meta`].


### PR DESCRIPTION
Add missing custom field handling to the `meta-spec` object. All others were in place. Also test that objects and arrays are preserved and remove the unused `ser::SerializeMap` and `Serializer` objects.