### PR TITLE
Rename Meta to Distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ All notable changes to this project will be documented in this file. It uses the
 
 ### ⚡ Improvements
 
-*   Added the [meta module], which loads v1 and v2 spec files, converts v1
-    metadata to v2, and merges multiple files.
+*   Added the [meta module], which loads v1 and v2 spec files into read-only
+    data structures, converts v1 metadata to v2, and merges multiple files.
 
 ### 🪲 Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# PGXN Meta
+# PGXN Distribution Metadata
 
-[![license-badge]][license] [![crates-badge]][crates] [![docs-badge]][docs] [![ci-badge]][ci] [![cov-badge]][cov] [![deps-badge]][deps]
+[![license-badge]][license] [![crates-badge]][crates] [![release-badge]][release] [![ci-badge]][ci] [![cov-badge]][cov] [![docs-badge]][docs] [![deps-badge]][deps]
 
 
-**The pgxn_meta crate provides [PGXN Meta Spec] validation**
+**The pgxn_meta crate provides PGXN Meta [v1] and [v2] validation and management**
 
 ---
 
-The [PGXN Meta Spec] defines the requirements for the metadata file
-(`META.json`) file for [PGXN] source distribution packages. This project
+The PGXN Meta [v1] and [v2] specs define the requirements for the metadata
+file (`META.json`) file for [PGXN] source distribution packages. This project
 provides Rust a crates for working with spec `META.json` files.
 
 Crate Usage
@@ -20,16 +20,16 @@ Crate Usage
 ```toml
 [dependencies]
 serde_json = "1.0"
-pgxn_meta = "0.1"
+pgxn_meta = "0.2"
 ```
 </details>
 
 ``` rust
 use serde_json::json;
-use pgxn_meta::*;
+use pgxn_meta::meta::Distribution;
 
 func main() {
-    // Parse the contents of a META.json file into a serde_json Value
+    // Load the contents of a META.json file into a serde_json::Value.
     let meta = json!({
       "name": "pair",
       "abstract": "A key/value pair data type",
@@ -45,10 +45,10 @@ func main() {
       "meta-spec": { "version": "1.0.0" }
     });
 
-    // Validate the META.json contents.
-    let mut validator = Validator::new();
-    if let Err(e) = validator.validate(&meta) {
-        panic!("Validation failed: {e}");
+    // Validate and load the META.json contents.
+    match Distribution::try_from(meta) {
+        Err(e) => panic!("Validation failed: {e}"),
+        Ok(dist) => println!("Loaded {} {}", dist.name(), dist.version()),
     };
 }
 ```
@@ -114,19 +114,22 @@ License
 
 This project is distributed under the [PostgreSQL License][license].
 
-  [license-badge]: https://img.shields.io/badge/License-PostgreSQL-blue.svg
+  [license-badge]: https://img.shields.io/badge/License-PostgreSQL-blue.svg "⚖️ PostgreSQL License"
   [license]: https://opensource.org/licenses/PostgreSQL "⚖️ PostgreSQL License"
-  [crates-badge]: https://img.shields.io/crates/v/pgxn_meta.svg
-  [crates]: https://crates.io/crates/pgxn_meta
-  [docs-badge]: https://docs.rs/pgxn_meta/badge.svg
-  [docs]: https://docs.rs/pgxn_meta
-  [ci-badge]: https://github.com/pgxn/meta/actions/workflows/test-and-lint.yml/badge.svg
+  [crates-badge]: https://img.shields.io/crates/v/pgxn_meta.svg "📦 Crate"
+  [crates]: https://crates.io/crates/pgxn_meta "📦 Crate"
+  [docs-badge]: https://docs.rs/pgxn_meta/badge.svg "📚 Docs Status"
+  [docs]: https://docs.rs/pgxn_meta "📚 Docs Status"
+  [ci-badge]: https://github.com/pgxn/meta/actions/workflows/test-and-lint.yml/badge.svg "🧪 Test and Lint"
   [ci]: https://github.com/pgxn/meta/actions/workflows/test-and-lint "🧪 Test and Lint"
-  [cov-badge]: https://codecov.io/gh/pgxn/meta/graph/badge.svg?token=5DOLLPIHEO
+  [cov-badge]: https://codecov.io/gh/pgxn/meta/graph/badge.svg?token=5DOLLPIHEO "📊 Code Coverage"
   [cov]: https://codecov.io/gh/pgxn/meta "📊 Code Coverage"
-  [deps-badge]: https://deps.rs/repo/github/pgxn/meta/status.svg
-  [deps]: https://deps.rs/repo/github/pgxn/meta "📦 Dependency Status"
-  [PGXN Meta Spec]: https://rfcs.pgxn.org/0001-meta-spec-v1.html
+  [deps-badge]: https://deps.rs/repo/github/pgxn/meta/status.svg "⬆️ Dependency Status"
+  [deps]: https://deps.rs/repo/github/pgxn/meta "⬆️ Dependency Status"
+  [release-badge]: https://img.shields.io/github/release/pgxn/meta.svg  "🚀 Latest Release"
+  [release]: https://github.com/pgxn/meta/releases/latest "🚀 Latest Release"
+  [v1]: https://rfcs.pgxn.org/0001-meta-spec-v1.html
+  [v2]: https://github.com/pgxn/rfcs/pull/3
   [PGXN]: https://pgxn.org "PGXN: PostgreSQL Extension Network"
   [`pgxn_meta` docs on docs.rs]: https://docs.rs/ubi/latest/pgxn_meta/
   [ubi]: https://github.com/houseabsolute/ubi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 #![deny(missing_docs)]
 #![deny(rustdoc::missing_crate_level_docs)]
 /*!
-PGXN Metadata validation.
+PGXN `META.json` validation and management.
 
-This crate uses JSON Schema to validate and inspect the PGXN `META.json`
+This crate uses JSON Schema to validate and inspect PGXN `META.json`
 files. It supports both the [v1] and [v2] specs.
 
 [v1]: https://rfcs.pgxn.org/0001-meta-spec-v1.html

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -1,8 +1,8 @@
 /*!
-PGXN Metadata management.
+PGXN `META.json` validation and management.
 
-This module provides interfaces to load, validate, and manipulate PGXN Meta
-Spec `META.json` files. It supports both the [v1] and [v2] specs.
+This module provides interfaces to load, validate, and manipulate PGXN
+`META.json` files. It supports both the [v1] and [v2] specs.
 
   [v1]: https://rfcs.pgxn.org/0001-meta-spec-v1.html
   [v2]: https://github.com/pgxn/rfcs/pull/3
@@ -19,7 +19,7 @@ use serde_json::Value;
 mod v1;
 mod v2;
 
-/// Represents the `meta-spec` object in [`Meta`].
+/// Represents the `meta-spec` object in [`Distribution`].
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct Spec {
     version: Version,
@@ -42,7 +42,8 @@ impl Spec {
     }
 }
 
-/// Maintainer represents an object in the list of `maintainers` in [`Meta`].
+/// Maintainer represents an object in the list of `maintainers` in
+/// [`Distribution`].
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct Maintainer {
     name: String,
@@ -293,7 +294,8 @@ impl App {
     }
 }
 
-/// Represents the contents of a distribution, under `contents` in [`Meta`].
+/// Represents the contents of a distribution, under `contents` in
+/// [`Distribution`].
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct Contents {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -331,7 +333,7 @@ impl Contents {
 }
 
 /// Represents the classifications of a distribution, under `classifications`
-/// in [`Meta`].
+/// in [`Distribution`].
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct Classifications {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -569,7 +571,7 @@ impl Variations {
     }
 }
 
-/// Defines the distribution dependencies under `dependencies` in [`Meta`].
+/// Defines the distribution dependencies under `dependencies` in [`Distribution`].
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct Dependencies {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -655,7 +657,7 @@ impl Badge {
     }
 }
 
-/// Defines the resources under `resources` in [`Meta`].
+/// Defines the resources under `resources` in [`Distribution`].
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct Resources {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -713,7 +715,7 @@ impl Resources {
     }
 }
 
-/// Defines the artifacts in the array under `artifacts` in [`Meta`].
+/// Defines the artifacts in the array under `artifacts` in [`Distribution`].
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct Artifact {
     url: String,
@@ -766,20 +768,20 @@ impl Artifact {
 /**
 Represents the `META.json` data from a PGXN distribution.
 
-Use the [TryFrom] traits to load a Meta object from a file, string, or
+Use the [TryFrom] traits to load a Distribution object from a file, string, or
 [serde_json::Value]. These constructors validate the `META.json` data against
 a JSON schema, provided by the [crate::valid] package. Once loaded, the data
 should never need to be modified; hence the read-only accessors to its
 contents.
 
 For cases where PGXN `META.json` data does need to be modified, use the
-[`TryFrom<&[&Value]>`](#impl-TryFrom%3C%26%5B%26Value%5D%3E-for-Meta) trait to
+[`TryFrom<&[&Value]>`](#impl-TryFrom%3C%26%5B%26Value%5D%3E-for-Distribution) trait to
 merge merge one or more [RFC 7396] patches.
 
   [RFC 7396]: https://www.rfc-editor.org/rfc/rfc7396.html
 */
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
-pub struct Meta {
+pub struct Distribution {
     name: String,
     version: Version,
     #[serde(rename = "abstract")]
@@ -823,9 +825,9 @@ where
         .collect())
 }
 
-impl Meta {
+impl Distribution {
     /// Deserializes `meta`, which contains PGXN `version` metadata, into a
-    /// [`Meta`].
+    /// [`Distribution`].
     fn from_version(version: u8, meta: Value) -> Result<Self, Box<dyn Error>> {
         match version {
             1 => v1::from_value(meta),
@@ -911,10 +913,10 @@ impl Meta {
     }
 }
 
-impl TryFrom<Value> for Meta {
+impl TryFrom<Value> for Distribution {
     type Error = Box<dyn Error>;
-    /// Converts the PGXN `META.json` data from `meta` into a [`Meta`].
-    /// Returns an error if `meta` is invalid.
+    /// Converts the PGXN `META.json` data from `meta` into a
+    /// [`Distribution`]. Returns an error if `meta` is invalid.
     ///
     /// # Example
     ///
@@ -943,7 +945,7 @@ impl TryFrom<Value> for Meta {
     /// });
     ///
     ///
-    /// let meta = Meta::try_from(meta_json);
+    /// let meta = Distribution::try_from(meta_json);
     /// assert!(meta.is_ok());
     /// ```
     fn try_from(meta: Value) -> Result<Self, Self::Error> {
@@ -953,14 +955,14 @@ impl TryFrom<Value> for Meta {
             Err(e) => return Err(Box::from(e.to_string())),
             Ok(v) => v,
         };
-        Meta::from_version(version, meta)
+        Distribution::from_version(version, meta)
     }
 }
 
-impl TryFrom<&[&Value]> for Meta {
+impl TryFrom<&[&Value]> for Distribution {
     type Error = Box<dyn Error>;
-    /// Merge multiple PGXN `META.json` data from `meta` into a [`Meta`].
-    /// Returns an error if `meta` is invalid.
+    /// Merge multiple PGXN `META.json` data from `meta` into a
+    /// [`Distribution`]. Returns an error if `meta` is invalid.
     ///
     /// The first value in `meta` should be the primary metadata, generally
     /// included in a distribution. Subsequent values will be merged into that
@@ -995,7 +997,7 @@ impl TryFrom<&[&Value]> for Meta {
     /// let patch = json!({"license": "MIT"});
     /// let all_meta = [&meta_json, &patch];
     ///
-    /// let meta = Meta::try_from(&all_meta[..]);
+    /// let meta = Distribution::try_from(&all_meta[..]);
     /// assert!(meta.is_ok());
     /// assert_eq!("MIT", meta.unwrap().license());
     /// ```
@@ -1025,11 +1027,11 @@ impl TryFrom<&[&Value]> for Meta {
         // Validate the patched doc and return.
         let mut validator = crate::valid::Validator::new();
         validator.validate(&v2).map_err(|e| e.to_string())?;
-        Meta::from_version(2, v2)
+        Distribution::from_version(2, v2)
     }
 }
 
-impl TryFrom<Meta> for Value {
+impl TryFrom<Distribution> for Value {
     type Error = Box<dyn Error>;
     /// Converts `meta` into a [serde_json::Value].
     ///
@@ -1060,42 +1062,42 @@ impl TryFrom<Meta> for Value {
     /// });
     ///
     ///
-    /// let meta = Meta::try_from(meta_json);
+    /// let meta = Distribution::try_from(meta_json);
     /// assert!(meta.is_ok());
     /// let val: Result<Value, Box<dyn Error>> = meta.unwrap().try_into();
     /// assert!(val.is_ok());
     /// ```
-    fn try_from(meta: Meta) -> Result<Self, Self::Error> {
+    fn try_from(meta: Distribution) -> Result<Self, Self::Error> {
         let val = serde_json::to_value(meta)?;
         Ok(val)
     }
 }
 
-impl TryFrom<&PathBuf> for Meta {
+impl TryFrom<&PathBuf> for Distribution {
     type Error = Box<dyn Error>;
-    /// Reads the `META.json` data from `file` then converts into a [`Meta`].
-    /// Returns an error on file error or if the content of `file` is not
-    /// valid PGXN `META.json` data.
+    /// Reads the `META.json` data from `file` then converts into a
+    /// [`Distribution`]. Returns an error on file error or if the content of
+    /// `file` is not valid PGXN `META.json` data.
     fn try_from(file: &PathBuf) -> Result<Self, Self::Error> {
         let meta: Value = serde_json::from_reader(File::open(file)?)?;
-        Meta::try_from(meta)
+        Distribution::try_from(meta)
     }
 }
 
-impl TryFrom<&String> for Meta {
+impl TryFrom<&String> for Distribution {
     type Error = Box<dyn Error>;
-    /// Converts `str` into JSON and then into  a [`Meta`]. Returns an error
-    /// if the content of `str` is not valid PGXN `META.json` data.
+    /// Converts `str` into JSON and then into  a [`Distribution`]. Returns an
+    /// error if the content of `str` is not valid PGXN `META.json` data.
     fn try_from(str: &String) -> Result<Self, Self::Error> {
         let meta: Value = serde_json::from_str(str)?;
-        Meta::try_from(meta)
+        Distribution::try_from(meta)
     }
 }
 
-impl TryFrom<Meta> for String {
+impl TryFrom<Distribution> for String {
     type Error = Box<dyn Error>;
     /// Converts `meta` into a JSON String.
-    fn try_from(meta: Meta) -> Result<Self, Self::Error> {
+    fn try_from(meta: Distribution) -> Result<Self, Self::Error> {
         let val = serde_json::to_string(&meta)?;
         Ok(val)
     }

--- a/src/meta/v1/mod.rs
+++ b/src/meta/v1/mod.rs
@@ -42,10 +42,10 @@ pub fn to_v2(v1: &Value) -> Result<Value, Box<dyn Error>> {
     Ok(Value::Object(v2))
 }
 
-/// from_value parses v1, which contains PGXN v1 metadata, into a Meta object
-/// containing valid PGXN v2 metadata.
-pub fn from_value(v1: Value) -> Result<Meta, Box<dyn Error>> {
-    Meta::try_from(to_v2(&v1)?)
+/// from_value parses v1, which contains PGXN v1 metadata, into a
+/// [`Distribution`] object containing valid PGXN v2 metadata.
+pub fn from_value(v1: Value) -> Result<Distribution, Box<dyn Error>> {
+    Distribution::try_from(to_v2(&v1)?)
 }
 
 /// v1_to_v2_common sets up a new v2 map with compatible fields copied from v1

--- a/src/meta/v2/mod.rs
+++ b/src/meta/v2/mod.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub fn from_value(meta: Value) -> Result<Meta, Box<dyn Error>> {
+pub fn from_value(meta: Value) -> Result<Distribution, Box<dyn Error>> {
     match serde_json::from_value(meta) {
         Ok(m) => Ok(m),
         Err(e) => Err(Box::from(e)),

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,3 +1,31 @@
 mod common;
 mod v1;
 mod v2;
+
+#[test]
+fn test_readme_example() {
+    use crate::meta::Distribution;
+    use serde_json::json;
+
+    // Load the contents of a META.json file into a serde_json::Value.
+    let meta = json!({
+      "name": "pair",
+      "abstract": "A key/value pair data type",
+      "version": "0.1.8",
+      "maintainer": "theory <theory@pgxn.org>",
+      "license": "postgresql",
+      "provides": {
+        "pair": {
+          "file": "sql/pair.sql",
+          "version": "0.1.8"
+        }
+      },
+      "meta-spec": { "version": "1.0.0" }
+    });
+
+    // Validate and load the META.json contents.
+    match Distribution::try_from(meta) {
+        Err(e) => panic!("Validation failed: {e}"),
+        Ok(dist) => println!("Loaded {} {}", dist.name(), dist.version()),
+    };
+}

--- a/src/valid/mod.rs
+++ b/src/valid/mod.rs
@@ -1,7 +1,7 @@
 /*!
-PGXN Metadata validation.
+PGXN Distribution Metadata validation.
 
-This module uses JSON Schema to validate PGXN Meta Spec `META.json` files.
+This module uses JSON Schema to validate PGXN `META.json` files.
 It supports both the [v1] and [v2] specs.
 
 # Example
@@ -104,11 +104,11 @@ impl Validator {
         }
     }
 
-    /// Validates a PGXN Meta document.
+    /// Validates PGXN Distribution metadata.
     ///
     /// Load a `META.json` file into a serde_json::value::Value and pass it
-    /// for validation. Returns a the Meta spec version on success and a
-    /// validation error on failure.
+    /// for validation. Returns the Meta spec version (1 or 2) on success and
+    /// a validation error on failure.
     ///
     /// See the [module docs](crate::valid) for an example.
     pub fn validate<'a>(&'a mut self, meta: &'a Value) -> Result<u8, Box<dyn Error + 'a>> {


### PR DESCRIPTION
And update all the docs to reflect this change. Also update the README example to load metadata into a Distribution object, rather than just validate --- and add a test for it.

While at it, add a release badge to the README and tweak the bad alt text emoji.