### PR TITLE
Remove sha256 from artifacts

### DIFF
--- a/corpus/v2/postgresml.json
+++ b/corpus/v2/postgresml.json
@@ -136,12 +136,12 @@
     {
       "type": "source",
       "url": "https://github.com/postgresml/postgresml/archive/refs/tags/v2.8.2.zip",
-      "sha256": "2b9d2416096d2930be51e5332b70bcd97846947777a93e4a3d65fe1b5fd7b004"
+      "sha512": "1218fdc10f1fe935e207307665dad62af3093a60c3fd483940a23420942a44044c7d820cf69b19449f439e1f498006563ba13d35f106fc168994a0590242ff0e"
     },
     {
       "type": "source",
       "url": "https://github.com/postgresml/postgresml/archive/refs/tags/v2.8.2.tar.gz",
-      "sha256": "845f28339c6159ac32daccea1cd17b386ea083c3e60bb8d58fb737725afe7eb5"
+      "sha512": "d7f3312717e60dac31312544f1735335844bac61a56240376e26e2b3e017e893ea6f7933a80a768b42e0d1d6e09fc95fdbd170ddd73609fe4e269bfb4f94740a"
     }
   ]
 }

--- a/corpus/v2/typical-c.json
+++ b/corpus/v2/typical-c.json
@@ -55,7 +55,7 @@
     {
       "type": "source",
       "url": "https://github.com/theory/pg-envvar/releases/download/v1.0.0/envvar-1.0.0.zip",
-      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      "sha512": "4eb99f3a53d31828fe04e098efe4354066b102e5cecaaa2fb638654cf85665b806b4727e40e4c8fd179a942df1658723ee48c805b73fd75cccfb6c9aa15fc58f"
     }
   ]
 }

--- a/corpus/v2/typical-pgrx.json
+++ b/corpus/v2/typical-pgrx.json
@@ -79,7 +79,7 @@
     {
       "type": "source",
       "url": "https://github.com/tembo-io/pg-jsonschema-boon/releases/download/v0.1.1/jsonschema-0.1.1.zip",
-      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      "sha512": "cfd9447575acb764aba6eb01c9c8ce75a5975c3be103d330a6a22b1a5ff85af8392fd348569b0eefd2d033232c0a5bffead3309d9c39759788889b51d79dd6ef"
     }
   ]
 }

--- a/corpus/v2/typical-sql.json
+++ b/corpus/v2/typical-sql.json
@@ -56,7 +56,7 @@
     {
       "type": "source",
       "url": "https://github.com/theory/kv-pair/releases/download/v0.1.7/pair-0.1.7.zip",
-      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      "sha512": "b353b5a82b3b54e95f4a2859e7a2bd0648abcb35a7c3612b126c2c75438fc2f8e8ee1f19e61f30fa54d7bb64bcf217ed1264722b497bcb613f82d78751515b67"
     }
   ]
 }

--- a/schema/v2/artifacts.schema.json
+++ b/schema/v2/artifacts.schema.json
@@ -23,21 +23,13 @@
         "$ref": "platform.schema.json",
         "description": "Identifies the platform the artifact was built for. **RECOMMENDED** for packages compiled for a specific platform, such as a C extension compiled for `linux-arm64`."
       },
-      "sha256": {
-        "type": "string",
-        "pattern": "^[0-9a-fA-F]{64}$",
-        "description": "The SHA-256 checksum for the artifact in hex format."
-      },
       "sha512": {
         "type": "string",
         "pattern": "^[0-9a-fA-F]{128}$",
         "description": "The SHA-512 checksum for the artifact in hex format."
       }
     },
-    "anyOf": [
-      { "required": ["url", "type", "sha256"] },
-      { "required": ["url", "type", "sha512"] }
-    ],
+    "required": ["url", "type", "sha512"],
     "patternProperties": { "^[xX]_.": { "description": "Custom key" } },
     "additionalProperties": false
   },
@@ -46,12 +38,12 @@
       {
         "type": "source",
         "url": "https://github.com/theory/pg-pair/releases/download/v1.1.0/pair-1.1.0.zip",
-        "sha256": "2b9d2416096d2930be51e5332b70bcd97846947777a93e4a3d65fe1b5fd7b004"
+        "sha512": "55570a7de3f0dcf714c25f5d7f1eaf2f00c9a093e02e113d65f479368f30e93b5a2475c3452d63df89b5f612ac99be538acc08c2eb82a9d536f27562dca9482f"
       },
       {
         "type": "binary",
         "url": "https://github.com/theory/pg-pair/releases/download/v1.1.0/pair-1.1.0-linux-amd64.tar.gz",
-        "sha256": "ec33656ba693c01be2b2b500c639846fb0ede7f7f8ee1f4c157bc9cab53c8500"
+        "sha512": "f140129b1b3ed7b4ef123e18abe695acc32167e9d452afd0265ed2f2781777f813c614482e7516bbeb1c92d9ed2f62e7b1b4296102cd5c3a22049a3b2d51c3bd"
       },
       {
         "type": "binary",

--- a/src/tests/v2.rs
+++ b/src/tests/v2.rs
@@ -2452,7 +2452,7 @@ fn test_v2_artifacts() -> Result<(), Box<dyn Error>> {
             json!([{
                 "url": "x:y",
                 "type": "bin",
-                "sha256": "0b68ee2ce5b2c0641c6c429ed2ce17e2ed76ddd58bf9a16e698c5069d60aa34e",
+                "sha512": "22e06f682a7fec79f814f06b5dcea0b06133890775ddc624de744cd5d4e8d5fe29863ba5e77c6d3690b610dbcdf7d79a973561fdfbd8454508998446af8f2c58",
             }]),
         ),
         (
@@ -2461,7 +2461,7 @@ fn test_v2_artifacts() -> Result<(), Box<dyn Error>> {
                 {
                     "url": "x:y",
                     "type": "bin",
-                    "sha256": "0b68ee2ce5b2c0641c6c429ed2ce17e2ed76ddd58bf9a16e698c5069d60aa34e",
+                    "sha512": "8002967263d2c9e8fed6600795f051d1ead470cfb022cd9a8fd4ee5f2a5147aa8a8814c43714401a8754c70aef01fd39060690dfd3e4a09acdb5a2c5586ffaf3",
                 },
                 {
                     "url": "a:b",
@@ -2477,7 +2477,7 @@ fn test_v2_artifacts() -> Result<(), Box<dyn Error>> {
                     "url": "x:y",
                     "type": "bin",
                     "platform": "linux",
-                    "sha256": "0B68EE2CE5B2C0641C6C429ED2CE17E2ED76DDD58BF9A16E698C5069D60AA34E",
+                    "sha512": "297fd4fcd863b31768e8da9900bbef5095f25707585e0aa67ca992e491468e9109dc9d3921eb13499003cc6ebe48fde62162ffb5bbcc4a1c5762c911cdc9efcd",
                 },
                 {
                     "url": "a:b",
@@ -2492,7 +2492,7 @@ fn test_v2_artifacts() -> Result<(), Box<dyn Error>> {
             json!([{
                 "url": "x:y",
                 "type": "bin",
-                "sha256": "0b68ee2ce5b2c0641c6c429ed2ce17e2ed76ddd58bf9a16e698c5069d60aa34e",
+                "sha512": "297fd4fcd863b31768e8da9900bbef5095f25707585e0aa67ca992e491468e9109dc9d3921eb13499003cc6ebe48fde62162ffb5bbcc4a1c5762c911cdc9efcd",
                 "x_y": 1,
             }]),
         ),
@@ -2501,7 +2501,7 @@ fn test_v2_artifacts() -> Result<(), Box<dyn Error>> {
             json!([{
                 "url": "x:y",
                 "type": "bin",
-                "sha256": "0b68ee2ce5b2c0641c6c429ed2ce17e2ed76ddd58bf9a16e698c5069d60aa34e",
+                "sha512": "297fd4fcd863b31768e8da9900bbef5095f25707585e0aa67ca992e491468e9109dc9d3921eb13499003cc6ebe48fde62162ffb5bbcc4a1c5762c911cdc9efcd",
                 "X_y": true,
             }]),
         ),
@@ -2526,7 +2526,7 @@ fn test_v2_artifacts() -> Result<(), Box<dyn Error>> {
             json!([{
                 "url": "x:y",
                 "type": "bin",
-                "sha256": "0b68ee2ce5b2c0641c6c429ed2ce17e2ed76ddd58bf9a16e698c5069d60aa34e",
+                "sha512": "297fd4fcd863b31768e8da9900bbef5095f25707585e0aa67ca992e491468e9109dc9d3921eb13499003cc6ebe48fde62162ffb5bbcc4a1c5762c911cdc9efcd",
                 "x_": 1,
             }]),
         ),
@@ -2535,7 +2535,7 @@ fn test_v2_artifacts() -> Result<(), Box<dyn Error>> {
             json!([{
                 "url": "x:y",
                 "type": "bin",
-                "sha256": "0b68ee2ce5b2c0641c6c429ed2ce17e2ed76ddd58bf9a16e698c5069d60aa34e",
+                "sha512": "297fd4fcd863b31768e8da9900bbef5095f25707585e0aa67ca992e491468e9109dc9d3921eb13499003cc6ebe48fde62162ffb5bbcc4a1c5762c911cdc9efcd",
                 "X_": 1,
             }]),
         ),
@@ -2544,7 +2544,7 @@ fn test_v2_artifacts() -> Result<(), Box<dyn Error>> {
             json!([{
                 "url": "x:y",
                 "type": "bin",
-                "sha256": "0b68ee2ce5b2c0641c6c429ed2ce17e2ed76ddd58bf9a16e698c5069d60aa34e",
+                "sha512": "297fd4fcd863b31768e8da9900bbef5095f25707585e0aa67ca992e491468e9109dc9d3921eb13499003cc6ebe48fde62162ffb5bbcc4a1c5762c911cdc9efcd",
                 "foo": 1,
             }]),
         ),
@@ -2553,7 +2553,7 @@ fn test_v2_artifacts() -> Result<(), Box<dyn Error>> {
             "url array",
             json!([{
                 "type": "bin",
-                "sha256": "0b68ee2ce5b2c0641c6c429ed2ce17e2ed76ddd58bf9a16e698c5069d60aa34e",
+                "sha512": "297fd4fcd863b31768e8da9900bbef5095f25707585e0aa67ca992e491468e9109dc9d3921eb13499003cc6ebe48fde62162ffb5bbcc4a1c5762c911cdc9efcd",
                 "url": [],
             }]),
         ),
@@ -2561,7 +2561,7 @@ fn test_v2_artifacts() -> Result<(), Box<dyn Error>> {
             "url object",
             json!([{
                 "type": "bin",
-                "sha256": "0b68ee2ce5b2c0641c6c429ed2ce17e2ed76ddd58bf9a16e698c5069d60aa34e",
+                "sha512": "297fd4fcd863b31768e8da9900bbef5095f25707585e0aa67ca992e491468e9109dc9d3921eb13499003cc6ebe48fde62162ffb5bbcc4a1c5762c911cdc9efcd",
                 "url": {},
             }]),
         ),
@@ -2569,7 +2569,7 @@ fn test_v2_artifacts() -> Result<(), Box<dyn Error>> {
             "url empty",
             json!([{
                 "type": "bin",
-                "sha256": "0b68ee2ce5b2c0641c6c429ed2ce17e2ed76ddd58bf9a16e698c5069d60aa34e",
+                "sha512": "297fd4fcd863b31768e8da9900bbef5095f25707585e0aa67ca992e491468e9109dc9d3921eb13499003cc6ebe48fde62162ffb5bbcc4a1c5762c911cdc9efcd",
                 "url": "",
             }]),
         ),
@@ -2577,7 +2577,7 @@ fn test_v2_artifacts() -> Result<(), Box<dyn Error>> {
             "url bool",
             json!([{
                 "type": "bin",
-                "sha256": "0b68ee2ce5b2c0641c6c429ed2ce17e2ed76ddd58bf9a16e698c5069d60aa34e",
+                "sha512": "297fd4fcd863b31768e8da9900bbef5095f25707585e0aa67ca992e491468e9109dc9d3921eb13499003cc6ebe48fde62162ffb5bbcc4a1c5762c911cdc9efcd",
                 "url": false,
             }]),
         ),
@@ -2585,7 +2585,7 @@ fn test_v2_artifacts() -> Result<(), Box<dyn Error>> {
             "url number",
             json!([{
                 "type": "bin",
-                "sha256": "0b68ee2ce5b2c0641c6c429ed2ce17e2ed76ddd58bf9a16e698c5069d60aa34e",
+                "sha512": "297fd4fcd863b31768e8da9900bbef5095f25707585e0aa67ca992e491468e9109dc9d3921eb13499003cc6ebe48fde62162ffb5bbcc4a1c5762c911cdc9efcd",
                 "url": 42,
             }]),
         ),
@@ -2593,7 +2593,7 @@ fn test_v2_artifacts() -> Result<(), Box<dyn Error>> {
             "url null",
             json!([{
                 "type": "bin",
-                "sha256": "0b68ee2ce5b2c0641c6c429ed2ce17e2ed76ddd58bf9a16e698c5069d60aa34e",
+                "sha512": "297fd4fcd863b31768e8da9900bbef5095f25707585e0aa67ca992e491468e9109dc9d3921eb13499003cc6ebe48fde62162ffb5bbcc4a1c5762c911cdc9efcd",
                 "url": null,
             }]),
         ),
@@ -2601,7 +2601,7 @@ fn test_v2_artifacts() -> Result<(), Box<dyn Error>> {
             "url invalid",
             json!([{
                 "type": "bin",
-                "sha256": "0b68ee2ce5b2c0641c6c429ed2ce17e2ed76ddd58bf9a16e698c5069d60aa34e",
+                "sha512": "297fd4fcd863b31768e8da9900bbef5095f25707585e0aa67ca992e491468e9109dc9d3921eb13499003cc6ebe48fde62162ffb5bbcc4a1c5762c911cdc9efcd",
                 "url": "not a uri",
             }]),
         ),
@@ -2610,7 +2610,7 @@ fn test_v2_artifacts() -> Result<(), Box<dyn Error>> {
             "type array",
             json!([{
                 "url": "x:y",
-                "sha256": "0b68ee2ce5b2c0641c6c429ed2ce17e2ed76ddd58bf9a16e698c5069d60aa34e",
+                "sha512": "297fd4fcd863b31768e8da9900bbef5095f25707585e0aa67ca992e491468e9109dc9d3921eb13499003cc6ebe48fde62162ffb5bbcc4a1c5762c911cdc9efcd",
                 "type": [],
             }]),
         ),
@@ -2618,7 +2618,7 @@ fn test_v2_artifacts() -> Result<(), Box<dyn Error>> {
             "type object",
             json!([{
                 "url": "x:y",
-                "sha256": "0b68ee2ce5b2c0641c6c429ed2ce17e2ed76ddd58bf9a16e698c5069d60aa34e",
+                "sha512": "297fd4fcd863b31768e8da9900bbef5095f25707585e0aa67ca992e491468e9109dc9d3921eb13499003cc6ebe48fde62162ffb5bbcc4a1c5762c911cdc9efcd",
                 "type": {},
             }]),
         ),
@@ -2626,7 +2626,7 @@ fn test_v2_artifacts() -> Result<(), Box<dyn Error>> {
             "type empty",
             json!([{
                 "url": "x:y",
-                "sha256": "0b68ee2ce5b2c0641c6c429ed2ce17e2ed76ddd58bf9a16e698c5069d60aa34e",
+                "sha512": "297fd4fcd863b31768e8da9900bbef5095f25707585e0aa67ca992e491468e9109dc9d3921eb13499003cc6ebe48fde62162ffb5bbcc4a1c5762c911cdc9efcd",
                 "type": "",
             }]),
         ),
@@ -2634,7 +2634,7 @@ fn test_v2_artifacts() -> Result<(), Box<dyn Error>> {
             "type bool",
             json!([{
                 "url": "x:y",
-                "sha256": "0b68ee2ce5b2c0641c6c429ed2ce17e2ed76ddd58bf9a16e698c5069d60aa34e",
+                "sha512": "297fd4fcd863b31768e8da9900bbef5095f25707585e0aa67ca992e491468e9109dc9d3921eb13499003cc6ebe48fde62162ffb5bbcc4a1c5762c911cdc9efcd",
                 "type": false,
             }]),
         ),
@@ -2642,7 +2642,7 @@ fn test_v2_artifacts() -> Result<(), Box<dyn Error>> {
             "type number",
             json!([{
                 "url": "x:y",
-                "sha256": "0b68ee2ce5b2c0641c6c429ed2ce17e2ed76ddd58bf9a16e698c5069d60aa34e",
+                "sha512": "297fd4fcd863b31768e8da9900bbef5095f25707585e0aa67ca992e491468e9109dc9d3921eb13499003cc6ebe48fde62162ffb5bbcc4a1c5762c911cdc9efcd",
                 "type": 42,
             }]),
         ),
@@ -2650,7 +2650,7 @@ fn test_v2_artifacts() -> Result<(), Box<dyn Error>> {
             "type null",
             json!([{
                 "url": "x:y",
-                "sha256": "0b68ee2ce5b2c0641c6c429ed2ce17e2ed76ddd58bf9a16e698c5069d60aa34e",
+                "sha512": "297fd4fcd863b31768e8da9900bbef5095f25707585e0aa67ca992e491468e9109dc9d3921eb13499003cc6ebe48fde62162ffb5bbcc4a1c5762c911cdc9efcd",
                 "type": null,
             }]),
         ),
@@ -2658,81 +2658,8 @@ fn test_v2_artifacts() -> Result<(), Box<dyn Error>> {
             "type too short",
             json!([{
                 "url": "x:y",
-                "sha256": "0b68ee2ce5b2c0641c6c429ed2ce17e2ed76ddd58bf9a16e698c5069d60aa34e",
+                "sha512": "297fd4fcd863b31768e8da9900bbef5095f25707585e0aa67ca992e491468e9109dc9d3921eb13499003cc6ebe48fde62162ffb5bbcc4a1c5762c911cdc9efcd",
                 "type": "x",
-            }]),
-        ),
-        // sha256
-        (
-            "sha256 array",
-            json!([{
-                "url": "x:y",
-                "type": "bin",
-                "sha256": [],
-            }]),
-        ),
-        (
-            "sha256 object",
-            json!([{
-                "url": "x:y",
-                "type": "bin",
-                "sha256": {},
-            }]),
-        ),
-        (
-            "sha256 empty",
-            json!([{
-                "url": "x:y",
-                "type": "bin",
-                "sha256": "",
-            }]),
-        ),
-        (
-            "sha256 bool",
-            json!([{
-                "url": "x:y",
-                "type": "bin",
-                "sha256": false,
-            }]),
-        ),
-        (
-            "sha256 number",
-            json!([{
-                "url": "x:y",
-                "type": "bin",
-                "sha256": 42,
-            }]),
-        ),
-        (
-            "sha256 null",
-            json!([{
-                "url": "x:y",
-                "type": "bin",
-                "sha256": null,
-            }]),
-        ),
-        (
-            "sha256 not hex",
-            json!([{
-                "url": "x:y",
-                "type": "bin",
-                "sha256": "0b68ee2ce5b2c0641c6c429ed2ce17e2ed76ddd58bf9a16e698c5069d60aa34x",
-            }]),
-        ),
-        (
-            "sha256 too long",
-            json!([{
-                "url": "x:y",
-                "type": "bin",
-                "sha256": "0b68ee2ce5b2c0641c6c429ed2ce17e2ed76ddd58bf9a16e698c5069d60aa34ee",
-            }]),
-        ),
-        (
-            "sha256 too short",
-            json!([{
-                "url": "x:y",
-                "type": "bin",
-                "sha256": "0b68ee2ce5b2c0641c6c429ed2ce17e2ed76ddd58bf9a16e698c5069d60aa34",
             }]),
         ),
         // sha512
@@ -3034,7 +2961,7 @@ fn test_v2_distribution() -> Result<(), Box<dyn Error>> {
                 json!([{
                     "type": "source",
                     "url": "https://github.com/theory/pg-pair/releases/download/v1.1.0/pair-1.1.0.zip",
-                    "sha256": "2b9d2416096d2930be51e5332b70bcd97846947777a93e4a3d65fe1b5fd7b004"
+                    "sha512": "b353b5a82b3b54e95f4a2859e7a2bd0648abcb35a7c3612b126c2c75438fc2f8e8ee1f19e61f30fa54d7bb64bcf217ed1264722b497bcb613f82d78751515b67"
                 }]),
             );
         }),


### PR DESCRIPTION
The standard these days is sha512, as seen in Homebrew, so just go with that and keep things simple.