### PR TITLE
Add release schema validation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,7 @@
 // build.rs
 
 use serde_json::{map::Map, Value};
-use std::{env, error::Error, fs::File, path::Path};
+use std::{env, error::Error, fs::File, io::Write, path::Path};
 use wax::Glob;
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -13,29 +13,23 @@ fn main() -> Result<(), Box<dyn Error>> {
 }
 
 fn merge_version(version: u8) -> Result<(), Box<dyn Error>> {
+    // Open the file to write each schema to.
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let dst_file = format!("pgxn-meta-v{version}.schemas.json");
+    let dst_path = Path::new(&out_dir).join(&dst_file);
+    let file = File::create(dst_path)?;
+
+    // Set up the search directory.
     let src_dir = Path::new("schema").join(format!("v{version}"));
     let glob = Glob::new("*.schema.json")?;
-    let mut defs = serde_json::map::Map::new();
 
+    // Write each file to the destination.
     for path in glob.walk(src_dir) {
         let path = &path?.into_path();
         let schema: Map<String, Value> = serde_json::from_reader(File::open(path)?)?;
-        // let id = schema["$id"].as_str().ok_or("No $id found in {path}")?;
-        let id = path.file_name().unwrap().to_str().unwrap();
-        defs.insert(id.to_string(), Value::Object(schema));
+        serde_json::to_writer(&file, &schema)?;
+        writeln!(&file)?;
     }
-
-    const ROOT: &str = "distribution.schema.json";
-    let mut dist = defs.remove(ROOT).unwrap();
-    dist.as_object_mut()
-        .unwrap()
-        .insert("$defs".to_string(), Value::Object(defs));
-
-    let out_dir = env::var_os("OUT_DIR").unwrap();
-    let dst_file = format!("pgxn-meta-v{version}.schema.json");
-    let dst_path = Path::new(&out_dir).join(&dst_file);
-    let file = File::create(dst_path)?;
-    serde_json::to_writer(&file, &dist)?;
 
     Ok(())
 }

--- a/src/valid/compiler/mod.rs
+++ b/src/valid/compiler/mod.rs
@@ -9,17 +9,19 @@ use serde_json::Value;
 /// new returns a new boon::Compiler with the schema files loaded from `dir`
 /// and configured to validate `path` and `license` formats.
 pub fn new() -> Compiler {
-    let schema_v1 = include_str!(concat!(env!("OUT_DIR"), "/pgxn-meta-v1.schema.json"));
-    let schema_v2 = include_str!(concat!(env!("OUT_DIR"), "/pgxn-meta-v2.schema.json"));
+    let schema_v1 = include_str!(concat!(env!("OUT_DIR"), "/pgxn-meta-v1.schemas.json"));
+    let schema_v2 = include_str!(concat!(env!("OUT_DIR"), "/pgxn-meta-v2.schemas.json"));
     let mut compiler = spec_compiler();
 
     for str in [schema_v1, schema_v2] {
-        let schema: Value = serde_json::from_str(str).unwrap();
-        let id = &schema["$id"]
-            .as_str()
-            .ok_or(super::ValidationError::UnknownID)
-            .unwrap();
-        compiler.add_resource(id, schema.to_owned()).unwrap();
+        for line in str.lines() {
+            let schema: Value = serde_json::from_str(line).unwrap();
+            let id = &schema["$id"]
+                .as_str()
+                .ok_or(super::ValidationError::UnknownID)
+                .unwrap();
+            compiler.add_resource(id, schema.to_owned()).unwrap();
+        }
     }
 
     compiler

--- a/src/valid/mod.rs
+++ b/src/valid/mod.rs
@@ -57,7 +57,7 @@ pub struct Validator {
 }
 
 /// Errors returned by Validator are ValidationError objects.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum ValidationError {
     /// UnknownSpec errors are returned when the validator cannot determine
     /// the version of the meta spec.
@@ -104,16 +104,40 @@ impl Validator {
         }
     }
 
-    /// Validates PGXN Distribution metadata.
+    /// Validates PGXN distribution metadata.
     ///
-    /// Load a `META.json` file into a serde_json::value::Value and pass it
-    /// for validation. Returns the Meta spec version (1 or 2) on success and
-    /// a validation error on failure.
+    /// Load a distribution `META.json` file into a serde_json::value::Value
+    /// and pass it for validation. Returns the Meta spec version (1 or 2) on
+    /// success and a validation error on failure.
     ///
     /// See the [module docs](crate::valid) for an example.
     pub fn validate<'a>(&'a mut self, meta: &'a Value) -> Result<u8, Box<dyn Error + 'a>> {
+        self.validate_schema(meta, "distribution.schema.json")
+    }
+
+    /// Validates PGXN release distribution metadata.
+    ///
+    /// On release, PGXN adds release metadata to the distribution `META.json`
+    /// and publishes it separately so that clients can find and validate a release.
+    /// The metadata includes the user who published the release, the release
+    /// timestamp, and checksums for the distribution file. The v2 spec goes
+    /// further by signing the release.
+    ///
+    /// This method validates the structure of such a release `META.json`
+    /// file. Load one up into a serde_json::value::Value and pass it for
+    /// validation. Returns the Meta spec version (1 or 2) on success and a
+    /// validation error on failure.
+    pub fn validate_release<'a>(&'a mut self, meta: &'a Value) -> Result<u8, Box<dyn Error + 'a>> {
+        self.validate_schema(meta, "release.schema.json")
+    }
+
+    fn validate_schema<'a>(
+        &'a mut self,
+        meta: &'a Value,
+        schema: &str,
+    ) -> Result<u8, Box<dyn Error + 'a>> {
         let v = util::get_version(meta).ok_or(ValidationError::UnknownSpec)?;
-        let id = format!("{SCHEMA_BASE}{v}/distribution.schema.json");
+        let id = format!("{SCHEMA_BASE}{v}/{schema}");
 
         let compiler = &mut self.compiler;
         let schemas = &mut self.schemas;
@@ -128,46 +152,65 @@ impl Validator {
 mod tests {
     use super::*;
     use serde_json::{json, Value};
-    use std::{
-        error::Error,
-        fs::File,
-        path::{Path, PathBuf},
-    };
+    use std::{error::Error, fs::File, path::PathBuf};
     use wax::Glob;
 
     #[test]
     fn test_corpus() -> Result<(), Box<dyn Error>> {
         let mut validator = Validator::default();
 
-        for v_dir in ["v1", "v2"] {
-            let dir: PathBuf = [env!("CARGO_MANIFEST_DIR"), "corpus", v_dir]
+        for (version, release_patch) in [
+            (
+                1,
+                json!({
+                  "user": "theory",
+                  "date": "2019-09-23T17:16:45Z",
+                  "sha1": "0389be689af6992b4da520ec510d147bae411e8b",
+                }),
+            ),
+            (
+                2,
+                json!({"release": {
+                  "headers": ["eyJhbGciOiJFUzI1NiJ9"],
+                  "signatures": [
+                    "DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSApmWQxfKTUJqPP3-Kg6NU1Q"
+                  ],
+                  "payload": {
+                    "user": "theory",
+                    "date": "2024-07-20T20:34:34Z",
+                    "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                    "digests": {
+                      "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
+                    }
+                  }
+                }}),
+            ),
+        ] {
+            let v_dir = format!("v{version}");
+            let dir: PathBuf = [env!("CARGO_MANIFEST_DIR"), "corpus", &v_dir]
                 .iter()
                 .collect();
             let glob = Glob::new("*.json")?;
 
             for path in glob.walk(dir) {
+                // Load metadata.
                 let path = path?.into_path();
-                let meta: Value = serde_json::from_reader(File::open(&path)?)?;
-                if let Err(e) = validator.validate(&meta) {
-                    panic!("{v_dir}/{:?} failed: {e}", path.file_name().unwrap());
-                }
-                println!("Example {v_dir}/{:?} ok", path.file_name().unwrap());
+                let bn = path.file_name().unwrap().to_str().unwrap();
+                let mut meta: Value = serde_json::from_reader(File::open(&path)?)?;
+
+                // Should validate.
+                match validator.validate(&meta) {
+                    Err(e) => panic!("{v_dir}/{bn} validate failed: {e}"),
+                    Ok(v) => assert_eq!(version, v, "{v_dir}/{bn} validate version"),
+                };
+
+                // Patch with release data and validate as release.
+                json_patch::merge(&mut meta, &release_patch);
+                match validator.validate_release(&meta) {
+                    Err(e) => panic!("{v_dir}/{bn} validate_release failed: {e}"),
+                    Ok(v) => assert_eq!(version, v, "{v_dir}/{bn} validate_release version"),
+                };
             }
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn test_validator() -> Result<(), Box<dyn Error>> {
-        let mut v = Validator::new();
-
-        for tc in [("v1", "widget.json"), ("v2", "typical-sql.json")] {
-            let path = Path::new(env!("CARGO_MANIFEST_DIR"))
-                .join("corpus")
-                .join(tc.0)
-                .join(tc.1);
-            let meta: Value = serde_json::from_reader(File::open(path)?)?;
-            assert!(v.validate(&meta).is_ok());
         }
 
         Ok(())
@@ -186,43 +229,193 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_schemas() -> Result<(), Box<dyn Error>> {
+    fn test_unknown_versions() -> Result<(), Box<dyn Error>> {
         let mut validator = Validator::new();
 
-        for tc in [
+        for (name, json) in [
             ("no meta spec", json!({})),
             ("meta spec array", json!({"meta-spec": []})),
             ("no meta version", json!({"meta-spec": {}})),
             ("meta version bool", json!({"meta-spec": true})),
             ("bad meta version", json!({"meta-spec": {"version": "0.0"}})),
         ] {
-            let res = validator.validate(&tc.1);
-            assert!(res.is_err());
+            match validator.validate(&json) {
+                Err(e) => assert_eq!(
+                    "Cannot determine meta-spec version",
+                    e.to_string(),
+                    "{name} validate"
+                ),
+                Ok(_) => panic!("{name} validate unexpectedly succeeded"),
+            }
+            match validator.validate_release(&json) {
+                Err(e) => assert_eq!(
+                    "Cannot determine meta-spec version",
+                    e.to_string(),
+                    "{name} validate_release"
+                ),
+                Ok(_) => panic!("{name} validate validate_release succeeded"),
+            }
+        }
+
+        Ok(())
+    }
+
+    fn load_minimal() -> Result<(Value, Value), Box<dyn Error>> {
+        let dir: PathBuf = [env!("CARGO_MANIFEST_DIR"), "corpus"].iter().collect();
+        let file = dir.join("v1").join("howto.json");
+        let v1: Value = serde_json::from_reader(File::open(file)?)?;
+        let file = dir.join("v2").join("minimal.json");
+        let v2: Value = serde_json::from_reader(File::open(file)?)?;
+        Ok((v1, v2))
+    }
+
+    #[test]
+    fn test_invalid_distribution() -> Result<(), Box<dyn Error>> {
+        let mut validator = Validator::new();
+        let (v1, v2) = load_minimal()?;
+
+        for (name, meta, patch, err) in [
+            (
+                "v1 no name",
+                &v1,
+                json!({"name": null}),
+                "missing properties 'name'",
+            ),
+            (
+                "v1 no version",
+                &v1,
+                json!({"version": null}),
+                "missing properties 'version'",
+            ),
+            (
+                "v1 invalid license",
+                &v1,
+                json!({"license": "lol no"}),
+                "'/license': oneOf failed, none matched",
+            ),
+            (
+                "v1 missing provides version",
+                &v1,
+                json!({"provides": {"pair": {"version": null}}}),
+                "missing properties 'version'",
+            ),
+            (
+                "v2 no name",
+                &v2,
+                json!({"name": null}),
+                "missing properties 'name'",
+            ),
+            (
+                "v2 no version",
+                &v2,
+                json!({"version": null}),
+                "missing properties 'version'",
+            ),
+            (
+                "v2 invalid license",
+                &v2,
+                json!({"license": "lol no"}),
+                "'/license': 'lol no' is not valid license: lol no",
+            ),
+            (
+                "v1 missing control",
+                &v1,
+                json!({"contents": {"extensions": {"pair": {"control": null}}}}),
+                "'/contents': false schema",
+            ),
+        ] {
+            let mut meta = meta.clone();
+            json_patch::merge(&mut meta, &patch);
+            match validator.validate(&meta) {
+                Err(e) => assert!(e.to_string().contains(err), "{name}: {e}"),
+                Ok(_) => panic!("{name} validate unexpectedly succeeded"),
+            };
+
+            match validator.validate_release(&meta) {
+                Err(e) => assert!(e.to_string().contains(err), "{name}: {e}"),
+                Ok(_) => panic!("{name} validate_release unexpectedly succeeded"),
+            };
         }
 
         Ok(())
     }
 
     #[test]
-    fn test_v1_meta() {
-        let meta = json!({
-          "name": "pair",
-          "abstract": "A key/value pair data type",
-          "version": "0.1.8",
-          "maintainer": "theory <theory@pgxn.org>",
-          "license": "postgresql",
-          "provides": {
-            "pair": {
-              "file": "sql/pair.sql",
-              "version": "0.1.8"
-            }
-          },
-          "meta-spec": { "version": "1.0.0" }
-        });
-
+    fn test_invalid_release() -> Result<(), Box<dyn Error>> {
         let mut validator = Validator::new();
-        if let Err(e) = validator.validate(&meta) {
-            panic!("Validation failed: {e}");
-        };
+        let (v1, v2) = load_minimal()?;
+        for (name, meta, patch, err) in [
+            (
+                "v1 no sha",
+                &v1,
+                json!({"user": "xxx", "date": "2019-09-23T17:16:45Z"}),
+                "missing properties 'sha1'",
+            ),
+            (
+                "v1 no user",
+                &v1,
+                json!({"sha1": "0389be689af6992b4da520ec510d147bae411e8b", "date": "2019-09-23T17:16:45Z"}),
+                "missing properties 'user'",
+            ),
+            (
+                "v1 no date",
+                &v1,
+                json!({"user": "xxx", "sha1": "0389be689af6992b4da520ec510d147bae411e8b"}),
+                "missing properties 'date'",
+            ),
+            (
+                "v2 no release",
+                &v2,
+                json!({}),
+                "missing properties 'release'",
+            ),
+            (
+                "v2 no release user",
+                &v2,
+                json!({"release": {
+                  "headers": ["eyJhbGciOiJFUzI1NiJ9"],
+                  "signatures": [
+                    "DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSApmWQxfKTUJqPP3-Kg6NU1Q"
+                  ],
+                  "payload": {
+                    "date": "2024-07-20T20:34:34Z",
+                    "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                    "digests": {
+                      "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
+                    }
+                  }
+                }}),
+                "'/release/payload': missing properties 'user'",
+            ),
+            (
+                "v2 no headers",
+                &v2,
+                json!({"release": {
+                  "headers": [],
+                  "signatures": [
+                    "DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSApmWQxfKTUJqPP3-Kg6NU1Q"
+                  ],
+                  "payload": {
+                    "user": "xxx",
+                    "date": "2024-07-20T20:34:34Z",
+                    "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                    "digests": {
+                      "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
+                    }
+                  }
+                }}),
+                "'/release/headers': minimum 1 items required, but got 0 items",
+            ),
+        ] {
+            let mut meta = meta.clone();
+            json_patch::merge(&mut meta, &patch);
+
+            match validator.validate_release(&meta) {
+                Err(e) => assert!(e.to_string().contains(err), "{name}: {e}"),
+                Ok(_) => panic!("{name} validate_release unexpectedly succeeded"),
+            };
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Rewrite `bulid.rs` to simply write each schema file on a single line instead of building up a merge structure. This allows each schema to be fetched from the compiler, rather than just `distribution.schema.json`. It's simpler, too.

Then update the `compiler` package to load each line into the compiler. This requires splitting the compiled-in `schema_v1` and `schema_v2` strings into lines, but it works just fine.

Add a new method to the `valid` package, `validate_release`, that validates a `META.json` file that includes release metadata. Since the functionality is identical to the existing `validate` method, aside from the schema name, refactor it into the new `validate_schema` method, now simply dispatched by both `validate` and `validate_release`.

Expand the corpus test to test both `validate` and `validate_release` by applying a patch containing valid release metadata. While there, add tests for the return values, to ensure that the correct verision is always returned from both methods.

Finally, eliminate some redundant tests and test the string values of errors, then add tests for validation failures for both `validate` and `validate_release`.