### PR TITLE
Add v1-v2 release conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cc"
 version = "1.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +500,7 @@ dependencies = [
  "hex",
  "json-patch",
  "lexopt",
+ "rand",
  "relative-path",
  "semver",
  "serde",
@@ -520,6 +527,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,6 +551,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -1026,6 +1072,7 @@ version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ chrono = { version = "0.4.38", features = ["serde"] }
 email_address = "0.2.9"
 json-patch = "2.0.0"
 lexopt = "0.3.0"
+rand = "0.8.5"
 relative-path = { version = "1.9", features = ["serde"] }
 semver = { version = "1.0", features = ["std", "serde"] }
 serde = { version = "1", features = ["derive"] }

--- a/schema/v2/pgxn-jws.schema.json
+++ b/schema/v2/pgxn-jws.schema.json
@@ -43,11 +43,11 @@
         "uri": {
           "type": "string",
           "format": "uri-reference",
-          "pattern": "^/dist/",
+          "pattern": "^dist/",
           "description": "Path to the release file relative to a PGXN base URL.",
           "examples": [
-            "/dist/pair/0.1.7/pair-0.1.7.zip",
-            "/dist/plv8/3.2.3/plv8-3.2.3.zip"
+            "dist/pair/0.1.7/pair-0.1.7.zip",
+            "dist/plv8/3.2.3/plv8-3.2.3.zip"
           ]
         },
         "digests": {
@@ -60,7 +60,7 @@
         {
           "user": "theory",
           "date": "2024-07-20T20:34:34Z",
-          "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+          "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
           "digests": {
             "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
           }
@@ -68,7 +68,7 @@
         {
           "user": "theory",
           "date": "2024-09-13T17:32:55Z",
-          "uri": "/dist/pair/0.1.7/pair-0.1.7.zip",
+          "uri": "dist/pair/0.1.7/pair-0.1.7.zip",
           "digests": {
             "sha256": "257b71aa57a28d62ddbb301333b3521ea3dc56f17551fa0e4516b03998abb089",
             "sha512": "b353b5a82b3b54e95f4a2859e7a2bd0648abcb35a7c3612b126c2c75438fc2f8e8ee1f19e61f30fa54d7bb64bcf217ed1264722b497bcb613f82d78751515b67"
@@ -88,7 +88,7 @@
       "payload": {
         "user": "theory",
         "date": "2024-07-20T20:34:34Z",
-        "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+        "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
         "digests": {
           "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
         }
@@ -103,7 +103,7 @@
       "payload": {
         "user": "theory",
         "date": "2024-09-13T17:32:55Z",
-        "uri": "/dist/pair/0.1.7/pair-0.1.7.zip",
+        "uri": "dist/pair/0.1.7/pair-0.1.7.zip",
         "digests": {
           "sha256": "257b71aa57a28d62ddbb301333b3521ea3dc56f17551fa0e4516b03998abb089",
           "sha512": "b353b5a82b3b54e95f4a2859e7a2bd0648abcb35a7c3612b126c2c75438fc2f8e8ee1f19e61f30fa54d7bb64bcf217ed1264722b497bcb613f82d78751515b67"

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -16,7 +16,7 @@ use semver::Version;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 
-mod v1;
+pub(crate) mod v1;
 mod v2;
 
 /// Represents the `meta-spec` object in [`Distribution`].

--- a/src/meta/v1/mod.rs
+++ b/src/meta/v1/mod.rs
@@ -1,5 +1,4 @@
-use super::*;
-
+use super::Distribution;
 use email_address::EmailAddress;
 use serde_json::{json, Map, Value};
 use std::{error::Error, str::FromStr};
@@ -10,7 +9,7 @@ pub fn to_v2(v1: &Value) -> Result<Value, Box<dyn Error>> {
     // Copy common fields.
     let mut v2 = v1_to_v2_common(v1);
 
-    // Convert maintainer.
+    // Convert maintainers.
     v2.insert("maintainers".to_string(), v1_to_v2_maintainers(v1)?);
 
     // Convert license.
@@ -45,7 +44,7 @@ pub fn to_v2(v1: &Value) -> Result<Value, Box<dyn Error>> {
 /// from_value parses v1, which contains PGXN v1 metadata, into a
 /// [`Distribution`] object containing valid PGXN v2 metadata.
 pub fn from_value(v1: Value) -> Result<Distribution, Box<dyn Error>> {
-    Distribution::try_from(to_v2(&v1)?)
+    to_v2(&v1)?.try_into()
 }
 
 /// v1_to_v2_common sets up a new v2 map with compatible fields copied from v1

--- a/src/meta/v1/tests.rs
+++ b/src/meta/v1/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use std::path::PathBuf;
+use std::{fs::File, path::PathBuf};
 
 #[test]
 fn test_v1_v2_common() {

--- a/src/release/v1/mod.rs
+++ b/src/release/v1/mod.rs
@@ -1,0 +1,65 @@
+use super::Release;
+use crate::meta::v1 as dist;
+use serde_json::{json, Value};
+use std::error::Error;
+
+/// to_v2 parses v1, which contains PGXN v1 release metadata, into a JSON
+/// object containing valid PGXN v2 release metadata.
+pub fn to_v2(v1: &Value) -> Result<Value, Box<dyn Error>> {
+    let mut v2_val = dist::to_v2(v1)?;
+    let v2 = v2_val
+        .as_object_mut()
+        .ok_or("Date returned from v1::to_v2 is not an object")?;
+
+    // Convert release.
+    v2.insert("release".to_string(), v1_to_v2_release(v1)?);
+
+    Ok(v2_val)
+}
+
+/// from_value parses v1, which contains PGXN v1 metadata, into a
+/// [`Release`] object containing valid PGXN v2 metadata.
+pub fn from_value(v1: Value) -> Result<Release, Box<dyn Error>> {
+    to_v2(&v1)?.try_into()
+}
+
+/// v1_to_v2_release clones release metadata from v1 to the v2 format. The
+/// included signature information will be random and un-verifiable, but
+/// adequate for v2 JSON Schema validation.
+fn v1_to_v2_release(v1: &Value) -> Result<Value, Box<dyn Error>> {
+    use rand::distributions::{Alphanumeric, DistString};
+    let mut field = "user";
+    if let Some(Value::String(user)) = v1.get(field) {
+        field = "date";
+        if let Some(Value::String(date)) = v1.get(field) {
+            field = "sha1";
+            if let Some(Value::String(sha1)) = v1.get(field) {
+                field = "name";
+                if let Some(Value::String(name)) = v1.get(field) {
+                    field = "version";
+                    if let Some(Value::String(version)) = v1.get(field) {
+                        let uri =
+                            format!("dist/{1}/{0}/{1}-{0}.zip", version.as_str(), name.as_str());
+                        // Generate random base64-ish values to mock headers
+                        // and signatures.
+                        let mut rng = rand::thread_rng();
+                        return Ok(json!({
+                            "headers": [format!("eyJ{}", Alphanumeric.sample_string(&mut rng, 13))],
+                            "signatures": [Alphanumeric.sample_string(&mut rng, 32)],
+                            "payload": {
+                                "user": user,
+                                "date": date,
+                                "uri": uri,
+                                "digests": {"sha1": sha1},
+                            }
+                        }));
+                    }
+                }
+            }
+        }
+    }
+    Err(Box::from(format!("missing release property {:?}", field)))
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/release/v1/tests.rs
+++ b/src/release/v1/tests.rs
@@ -1,0 +1,88 @@
+use super::*;
+
+#[test]
+fn test_v1_v2_release() {
+    let mut prev_head = "x".repeat(16);
+    let mut prev_sig = "x".repeat(32);
+
+    for (name, input) in [
+        (
+            "basics",
+            json!({
+              "name": "pair",
+              "version": "1.2.3",
+              "user": "xxx",
+              "date": "2024-09-18T15:38:15Z",
+              "sha1": "d833511c7ebb9c1875426ca8a93edcacd0787c46",
+            }),
+        ),
+        (
+            "another",
+            json!({
+              "name": "semver",
+              "version": "3.4.5",
+              "user": "yyy",
+              "date": "2022-04-12T45:42:21.392Z",
+              "sha1": "3e59eff6779d2444d7e120436f675ff2868a0b39",
+            }),
+        ),
+    ] {
+        let v2 = v1_to_v2_release(&input).unwrap();
+        // Should have three keys.
+        assert_eq!(3, v2.as_object().unwrap().keys().len());
+
+        // Make sure the payload is correct.
+        let pay = v2.get("payload").unwrap();
+        assert_eq!(input.get("user"), pay.get("user"), "{name} user");
+        assert_eq!(input.get("date"), pay.get("date"), "{name} date");
+        let uri = Value::String(format!(
+            "dist/{0}/{1}/{0}-{1}.zip",
+            input.get("name").unwrap().as_str().unwrap(),
+            input.get("version").unwrap().as_str().unwrap(),
+        ));
+        assert_eq!(&uri, pay.get("uri").unwrap(), "{name} uri");
+
+        // Make sure headers contains 1 16-char random string.
+        let heads = v2.get("headers").unwrap().as_array().unwrap();
+        assert_eq!(1, heads.len());
+        let head = heads.first().unwrap().as_str().unwrap();
+        assert_eq!(16, head.len());
+        assert!(head.starts_with("eyJ"));
+        assert_ne!(&prev_head, head);
+        prev_head = head.to_string();
+
+        // Make sure signatures contains 1 32-char random string.
+        let sigs = v2.get("signatures").unwrap().as_array().unwrap();
+        assert_eq!(1, sigs.len());
+        let sig = sigs.first().unwrap().as_str().unwrap();
+        assert_eq!(32, sig.len());
+        assert_ne!(&prev_sig, sig);
+        prev_sig = sig.to_string();
+    }
+}
+
+#[test]
+fn test_v1_v2_release_err() {
+    for (name, input) in [
+        ("user", json!({})),
+        ("date", json!({"user": "xxx"})),
+        ("sha1", json!({"user": "xxx", "date": "today"})),
+        (
+            "name",
+            json!({"user": "xxx", "date": "today", "sha1": "123"}),
+        ),
+        (
+            "version",
+            json!({"user": "xxx", "date": "today", "sha1": "123", "name": "pair"}),
+        ),
+    ] {
+        match v1_to_v2_release(&input) {
+            Ok(_) => panic!("{name} unexpectedly succeeded"),
+            Err(e) => assert_eq!(
+                format!("missing release property \"{name}\""),
+                e.to_string(),
+                "{name}: {e}"
+            ),
+        }
+    }
+}

--- a/src/release/v2/mod.rs
+++ b/src/release/v2/mod.rs
@@ -1,8 +1,8 @@
-use super::Distribution;
+use super::Release;
 use serde_json::Value;
 use std::error::Error;
 
-pub fn from_value(meta: Value) -> Result<Distribution, Box<dyn Error>> {
+pub fn from_value(meta: Value) -> Result<Release, Box<dyn Error>> {
     match serde_json::from_value(meta) {
         Ok(m) => Ok(m),
         Err(e) => Err(Box::from(e)),

--- a/src/tests/v2.rs
+++ b/src/tests/v2.rs
@@ -3441,7 +3441,7 @@ fn test_v2_pgxn_jws() -> Result<(), Box<dyn Error>> {
               "payload": {
                 "user": "theory",
                 "date": "2024-07-20T20:34:34Z",
-                "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
                 "digests": {
                   "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
                 }
@@ -3459,7 +3459,7 @@ fn test_v2_pgxn_jws() -> Result<(), Box<dyn Error>> {
               "payload": {
                 "user": "theory",
                 "date": "2024-09-13T17:32:55Z",
-                "uri": "/dist/pair/0.1.7/pair-0.1.7.zip",
+                "uri": "dist/pair/0.1.7/pair-0.1.7.zip",
                 "digests": {
                   "sha256": "257b71aa57a28d62ddbb301333b3521ea3dc56f17551fa0e4516b03998abb089",
                   "sha512": "b353b5a82b3b54e95f4a2859e7a2bd0648abcb35a7c3612b126c2c75438fc2f8e8ee1f19e61f30fa54d7bb64bcf217ed1264722b497bcb613f82d78751515b67"
@@ -3476,7 +3476,7 @@ fn test_v2_pgxn_jws() -> Result<(), Box<dyn Error>> {
     let payload = json!({
       "user": "theory",
       "date": "2024-07-20T20:34:34Z",
-      "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+      "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
       "digests": {
         "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
       }
@@ -3847,7 +3847,7 @@ fn test_v2_pgxn_jws() -> Result<(), Box<dyn Error>> {
               "signatures": ["DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-"],
               "payload": {
                 "date": "2024-07-20T20:34:34Z",
-                "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
                 "digests": {
                   "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
                 }
@@ -3862,7 +3862,7 @@ fn test_v2_pgxn_jws() -> Result<(), Box<dyn Error>> {
               "payload": {
                 "user": "",
                 "date": "2024-07-20T20:34:34Z",
-                "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
                 "digests": {
                   "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
                 }
@@ -3877,7 +3877,7 @@ fn test_v2_pgxn_jws() -> Result<(), Box<dyn Error>> {
               "payload": {
                 "user": 42,
                 "date": "2024-07-20T20:34:34Z",
-                "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
                 "digests": {
                   "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
                 }
@@ -3892,7 +3892,7 @@ fn test_v2_pgxn_jws() -> Result<(), Box<dyn Error>> {
               "payload": {
                 "user": null,
                 "date": "2024-07-20T20:34:34Z",
-                "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
                 "digests": {
                   "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
                 }
@@ -3907,7 +3907,7 @@ fn test_v2_pgxn_jws() -> Result<(), Box<dyn Error>> {
               "payload": {
                 "user": true,
                 "date": "2024-07-20T20:34:34Z",
-                "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
                 "digests": {
                   "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
                 }
@@ -3922,7 +3922,7 @@ fn test_v2_pgxn_jws() -> Result<(), Box<dyn Error>> {
               "payload": {
                 "user": ["theory"],
                 "date": "2024-07-20T20:34:34Z",
-                "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
                 "digests": {
                   "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
                 }
@@ -3937,7 +3937,7 @@ fn test_v2_pgxn_jws() -> Result<(), Box<dyn Error>> {
               "payload": {
                 "user": {"x": "hi"},
                 "date": "2024-07-20T20:34:34Z",
-                "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
                 "digests": {
                   "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
                 }
@@ -3952,7 +3952,7 @@ fn test_v2_pgxn_jws() -> Result<(), Box<dyn Error>> {
               "payload": {
                 "user": "x",
                 "date": "2024-07-20T20:34:34Z",
-                "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
                 "digests": {
                   "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
                 }
@@ -3967,7 +3967,7 @@ fn test_v2_pgxn_jws() -> Result<(), Box<dyn Error>> {
               "signatures": ["DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-"],
               "payload": {
                 "user": "theory",
-                "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
                 "digests": {
                   "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
                 }
@@ -3982,7 +3982,7 @@ fn test_v2_pgxn_jws() -> Result<(), Box<dyn Error>> {
               "payload": {
                 "user": "theory",
                 "date": null,
-                "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
                 "digests": {
                   "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
                 }
@@ -3997,7 +3997,7 @@ fn test_v2_pgxn_jws() -> Result<(), Box<dyn Error>> {
               "payload": {
                 "user": "theory",
                 "date": true,
-                "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
                 "digests": {
                   "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
                 }
@@ -4012,7 +4012,7 @@ fn test_v2_pgxn_jws() -> Result<(), Box<dyn Error>> {
               "payload": {
                 "user": "theory",
                 "date": 42,
-                "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
                 "digests": {
                   "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
                 }
@@ -4027,7 +4027,7 @@ fn test_v2_pgxn_jws() -> Result<(), Box<dyn Error>> {
               "payload": {
                 "user": "theory",
                 "date": ["2024-07-20T20:34:34Z"],
-                "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
                 "digests": {
                   "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
                 }
@@ -4042,7 +4042,7 @@ fn test_v2_pgxn_jws() -> Result<(), Box<dyn Error>> {
               "payload": {
                 "user": "theory",
                 "date": {"x": "2024-07-20T20:34:34Z"},
-                "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
                 "digests": {
                   "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
                 }
@@ -4057,7 +4057,7 @@ fn test_v2_pgxn_jws() -> Result<(), Box<dyn Error>> {
               "payload": {
                 "user": "theory",
                 "date": ["2024-07-20T27:34:34Z"],
-                "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
                 "digests": {
                   "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
                 }
@@ -4192,7 +4192,7 @@ fn test_v2_pgxn_jws() -> Result<(), Box<dyn Error>> {
               "payload": {
                 "user": "theory",
                 "date": "2024-07-20T20:34:34Z",
-                "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
+                "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
                 "digests": {
                   "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
                 }
@@ -4208,7 +4208,7 @@ fn test_v2_pgxn_jws() -> Result<(), Box<dyn Error>> {
               "payload": {
                 "user": "theory",
                 "date": "2024-07-20T20:34:34Z",
-                "uri": "/dist/semver/0.40.0/semver-0.40.0.zip"
+                "uri": "dist/semver/0.40.0/semver-0.40.0.zip"
               },
             }),
         ),
@@ -4220,7 +4220,7 @@ fn test_v2_pgxn_jws() -> Result<(), Box<dyn Error>> {
               "payload": {
                 "user": "theory",
                 "date": "2024-07-20T20:34:34Z",
-                "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
                 "digests": {},
               },
             }),
@@ -4233,7 +4233,7 @@ fn test_v2_pgxn_jws() -> Result<(), Box<dyn Error>> {
               "payload": {
                 "user": "theory",
                 "date": "2024-07-20T20:34:34Z",
-                "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
                 "digests": { "sha1": "nope" },
               },
             }),
@@ -4246,7 +4246,7 @@ fn test_v2_pgxn_jws() -> Result<(), Box<dyn Error>> {
               "payload": {
                 "user": "theory",
                 "date": "2024-07-20T20:34:34Z",
-                "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
                 "digests": null,
               },
             }),
@@ -4259,7 +4259,7 @@ fn test_v2_pgxn_jws() -> Result<(), Box<dyn Error>> {
               "payload": {
                 "user": "theory",
                 "date": "2024-07-20T20:34:34Z",
-                "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
                 "digests": 42,
               },
             }),
@@ -4272,7 +4272,7 @@ fn test_v2_pgxn_jws() -> Result<(), Box<dyn Error>> {
               "payload": {
                 "user": "theory",
                 "date": "2024-07-20T20:34:34Z",
-                "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
                 "digests": "fe8c013f991b5f537c39fb0c0b04bc955457675a",
               },
             }),
@@ -4285,7 +4285,7 @@ fn test_v2_pgxn_jws() -> Result<(), Box<dyn Error>> {
               "payload": {
                 "user": "theory",
                 "date": "2024-07-20T20:34:34Z",
-                "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
                 "digests": ["fe8c013f991b5f537c39fb0c0b04bc955457675a"],
               },
             }),
@@ -4320,7 +4320,7 @@ fn test_v2_release() -> Result<(), Box<dyn Error>> {
               "payload": {
                 "user": "theory",
                 "date": "2024-07-20T20:34:34Z",
-                "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
                 "digests": {
                   "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
                 }
@@ -4338,7 +4338,7 @@ fn test_v2_release() -> Result<(), Box<dyn Error>> {
               "payload": {
                 "user": "theory",
                 "date": "2024-09-13T17:32:55Z",
-                "uri": "/dist/pair/0.1.7/pair-0.1.7.zip",
+                "uri": "dist/pair/0.1.7/pair-0.1.7.zip",
                 "digests": {
                   "sha256": "257b71aa57a28d62ddbb301333b3521ea3dc56f17551fa0e4516b03998abb089",
                   "sha512": "b353b5a82b3b54e95f4a2859e7a2bd0648abcb35a7c3612b126c2c75438fc2f8e8ee1f19e61f30fa54d7bb64bcf217ed1264722b497bcb613f82d78751515b67"
@@ -4405,7 +4405,7 @@ fn test_v2_release() -> Result<(), Box<dyn Error>> {
                   "payload": {
                     "user": "theory",
                     "date": "2024-07-20T20:34:34Z",
-                    "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                    "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
                     "digests": {
                       "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
                     }
@@ -4422,7 +4422,7 @@ fn test_v2_release() -> Result<(), Box<dyn Error>> {
                   ],
                   "payload": {
                     "date": "2024-07-20T20:34:34Z",
-                    "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                    "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
                     "digests": {
                       "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
                     }

--- a/src/valid/mod.rs
+++ b/src/valid/mod.rs
@@ -178,7 +178,7 @@ mod tests {
                   "payload": {
                     "user": "theory",
                     "date": "2024-07-20T20:34:34Z",
-                    "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                    "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
                     "digests": {
                       "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
                     }
@@ -379,7 +379,7 @@ mod tests {
                   ],
                   "payload": {
                     "date": "2024-07-20T20:34:34Z",
-                    "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                    "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
                     "digests": {
                       "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
                     }
@@ -398,7 +398,7 @@ mod tests {
                   "payload": {
                     "user": "xxx",
                     "date": "2024-07-20T20:34:34Z",
-                    "uri": "/dist/semver/0.40.0/semver-0.40.0.zip",
+                    "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
                     "digests": {
                       "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
                     }


### PR DESCRIPTION
Dupe the pattern from the `meta` package by adding `v1` and `v2` sub-packages that know how to parse into the canonical form. Make `meta::v1` public to the crate so that `release::v1` can use it to migrate everything but the release metadata, then add `v1_to_v2_release` to handle that bit.

The v2 `release` object takes the form of a JWS-JS data structure, but since we're not signing anything yet, and this is just to get things to load properly, for now just generate random values for the JWS header and signature.

While at it, change the `uri` property to start with `dist` instead of `/dist`, because the latter implies relative to the root of a domain, and mirrors may not serve from a domain root.