### PR TITLE
Add certs to release package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,6 +494,7 @@ name = "pgxn_meta"
 version = "0.3.0"
 dependencies = [
  "assert-json-diff",
+ "base64 0.22.1",
  "boon",
  "chrono",
  "email_address",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ exclude = [ ".github", ".vscode", ".gitignore", ".ci", ".pre-*.yaml"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+base64 = "0.22"
 boon = "0.6"
 chrono = { version = "0.4.38", features = ["serde"] }
 email_address = "0.2.9"

--- a/schema/v2/release.schema.json
+++ b/schema/v2/release.schema.json
@@ -9,9 +9,9 @@
     { "$ref": "base.schema.json" },
     {
       "properties": {
-        "release": { "$ref": "pgxn-jws.schema.json" }
+        "certs": { "$ref": "certs.schema.json" }
       },
-      "required": ["release"]
+      "required": ["certs"]
     }
   ]
 }

--- a/src/release/v1/mod.rs
+++ b/src/release/v1/mod.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Value};
 use std::error::Error;
 
 /// to_v2 parses v1, which contains PGXN v1 release metadata, into a JSON
-/// object containing valid PGXN v2 release metadata.
+/// object containing valid PGXN v2 release certification.
 pub fn to_v2(v1: &Value) -> Result<Value, Box<dyn Error>> {
     let mut v2_val = dist::to_v2(v1)?;
     let v2 = v2_val
@@ -12,7 +12,7 @@ pub fn to_v2(v1: &Value) -> Result<Value, Box<dyn Error>> {
         .ok_or("Date returned from v1::to_v2 is not an object")?;
 
     // Convert release.
-    v2.insert("release".to_string(), v1_to_v2_release(v1)?);
+    v2.insert("certs".to_string(), v1_to_v2_release(v1)?);
 
     Ok(v2_val)
 }
@@ -27,7 +27,9 @@ pub fn from_value(v1: Value) -> Result<Release, Box<dyn Error>> {
 /// included signature information will be random and un-verifiable, but
 /// adequate for v2 JSON Schema validation.
 fn v1_to_v2_release(v1: &Value) -> Result<Value, Box<dyn Error>> {
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
     use rand::distributions::{Alphanumeric, DistString};
+
     let mut field = "user";
     if let Some(Value::String(user)) = v1.get(field) {
         field = "date";
@@ -40,18 +42,24 @@ fn v1_to_v2_release(v1: &Value) -> Result<Value, Box<dyn Error>> {
                     if let Some(Value::String(version)) = v1.get(field) {
                         let uri =
                             format!("dist/{1}/{0}/{1}-{0}.zip", version.as_str(), name.as_str());
-                        // Generate random base64-ish values to mock headers
-                        // and signatures.
+
+                        // Assemble the payload.
+                        let payload = json!({
+                          "date": date,
+                          "digests": {"sha1": sha1},
+                          "uri": uri,
+                          "user": user,
+                        });
+                        let payload = serde_json::to_vec(&payload).unwrap();
+                        let payload = URL_SAFE_NO_PAD.encode(&payload);
+
+                        // Generate random base64-ish values to mock the signature.
                         let mut rng = rand::thread_rng();
                         return Ok(json!({
-                            "headers": [format!("eyJ{}", Alphanumeric.sample_string(&mut rng, 13))],
-                            "signatures": [Alphanumeric.sample_string(&mut rng, 32)],
-                            "payload": {
-                                "user": user,
-                                "date": date,
-                                "uri": uri,
-                                "digests": {"sha1": sha1},
-                            }
+                          "pgxn": {
+                            "payload": payload,
+                            "signature": Alphanumeric.sample_string(&mut rng, 32),
+                          },
                         }));
                     }
                 }

--- a/src/tests/v2.rs
+++ b/src/tests/v2.rs
@@ -5666,37 +5666,34 @@ fn test_v2_release() -> Result<(), Box<dyn Error>> {
     for (name, release_meta) in [
         (
             "basic",
-            json!({"release": {
-              "headers": ["eyJhbGciOiJFUzI1NiJ9"],
-              "signatures": [
-                "DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSApmWQxfKTUJqPP3-Kg6NU1Q"
-              ],
-              "payload": {
-                "user": "theory",
-                "date": "2024-07-20T20:34:34Z",
-                "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
-                "digests": {
-                  "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
-                }
+            json!({"certs": {
+              "pgxn": {
+                "payload": "eyJ1c2VyIjoidGhlb3J5IiwiZGF0ZSI6IjIwMjQtMDktMTNUMTc6MzI6NTVaIiwidXJpIjoiZGlzdC9wYWlyLzAuMS43L3BhaXItMC4xLjcuemlwIiwiZGlnZXN0cyI6eyJzaGE1MTIiOiJiMzUzYjVhODJiM2I1NGU5NWY0YTI4NTllN2EyYmQwNjQ4YWJjYjM1YTdjMzYxMmIxMjZjMmM3NTQzOGZjMmY4ZThlZTFmMTllNjFmMzBmYTU0ZDdiYjY0YmNmMjE3ZWQxMjY0NzIyYjQ5N2JjYjYxM2Y4MmQ3ODc1MTUxNWI2NyJ9fQ",
+                "signatures": [
+                   {
+                     "protected": "eyJhbGciOiJSUzI1NiJ9",
+                     "header": { "kid": "2024-12-29" },
+                     "signature": "cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZmh7AAuHIm4Bh-rLIARNPvkSjtQBMHlb1L07Qe7K0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZESc6BfI7noOPqvhJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AXLIhWkWywlVmtVrBp0igcN_IoypGlUPQGe77Rw"
+                   }
+                ]
               }
             }}),
         ),
         (
             "multi signature",
-            json!({"release": {
-              "headers": ["eyJhbGciOiJSUzI1NiJ9", "eyJhbGciOiJFUzI1NiJ9"],
-              "signatures": [
-                "cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZmh7AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjbKBYNX4BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHlb1L07Qe7K0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZESc6BfI7noOPqvhJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AXLIhWkWywlVmtVrBp0igcN_IoypGlUPQGe77Rw",
-                "DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSApmWQxfKTUJqPP3-Kg6NU1Q"
-              ],
-              "payload": {
-                "user": "theory",
-                "date": "2024-09-13T17:32:55Z",
-                "uri": "dist/pair/0.1.7/pair-0.1.7.zip",
-                "digests": {
-                  "sha256": "257b71aa57a28d62ddbb301333b3521ea3dc56f17551fa0e4516b03998abb089",
-                  "sha512": "b353b5a82b3b54e95f4a2859e7a2bd0648abcb35a7c3612b126c2c75438fc2f8e8ee1f19e61f30fa54d7bb64bcf217ed1264722b497bcb613f82d78751515b67"
-                }
+            json!({"certs": {
+              "pgxn": {
+                "payload": "eyJ1c2VyIjoidGhlb3J5IiwiZGF0ZSI6IjIwMjQtMDktMTNUMTc6MzI6NTVaIiwidXJpIjoiZGlzdC9wYWlyLzAuMS43L3BhaXItMC4xLjcuemlwIiwiZGlnZXN0cyI6eyJzaGE1MTIiOiJiMzUzYjVhODJiM2I1NGU5NWY0YTI4NTllN2EyYmQwNjQ4YWJjYjM1YTdjMzYxMmIxMjZjMmM3NTQzOGZjMmY4ZThlZTFmMTllNjFmMzBmYTU0ZDdiYjY0YmNmMjE3ZWQxMjY0NzIyYjQ5N2JjYjYxM2Y4MmQ3ODc1MTUxNWI2NyJ9fQ",
+                "signatures": [
+                   {
+                     "protected": "eyJhbGciOiJSUzI1NiJ9",
+                     "header": { "kid": "2024-12-29" },
+                     "signature": "cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZmh7AAuHIm4Bh-rLIARNPvkSjtQBMHlb1L07Qe7K0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZESc6BfI7noOPqvhJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AXLIhWkWywlVmtVrBp0igcN_IoypGlUPQGe77Rw"
+                   },
+                   {
+                    "signature": "DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSApmWQxfKTUJqPP3-Kg6NU1Q"
+                  }
+               ]
               }
             }}),
         ),
@@ -5714,80 +5711,58 @@ fn test_v2_release() -> Result<(), Box<dyn Error>> {
         }
 
         // Now try invalid cases.
-        for (name, release_meta, err) in [
+        for (name, certs_meta, err) in [
+            ("no certs field", json!({}), "missing properties 'certs'"),
             (
-                "no release field",
-                json!({}),
-                "missing properties 'release'",
+                "null certs",
+                json!({"certs": null}),
+                "missing properties 'certs'",
             ),
             (
-                "null release",
-                json!({"release": null}),
-                "missing properties 'release'",
+                "bool certs",
+                json!({"certs": true}),
+                "'/certs': want object, but got boolean",
             ),
             (
-                "bool release",
-                json!({"release": true}),
-                "'/release': want object, but got boolean",
+                "number certs",
+                json!({"certs": 42}),
+                "'/certs': want object, but got number",
             ),
             (
-                "number release",
-                json!({"release": 42}),
-                "'/release': want object, but got number",
-            ),
-            (
-                "string release",
-                json!({"release": "hi"}),
-                "'/release': want object, but got string",
+                "string certs",
+                json!({"certs": "hi"}),
+                "'/certs': want object, but got string",
             ),
             (
                 "bool array",
-                json!({"release": [true]}),
-                "'/release': want object, but got array",
+                json!({"certs": [true]}),
+                "'/certs': want object, but got array",
             ),
             (
                 "empty",
-                json!({"release": {}}),
-                "'/release': missing properties 'headers', 'signatures', 'payload'",
+                json!({"certs": {}}),
+                "'/certs': missing properties 'pgxn'",
             ),
             (
-                "missing headers",
-                json!({"release": {
+                "missing payload",
+                json!({"certs": {"pgxn": {
                   "signatures": [
                     "DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSApmWQxfKTUJqPP3-Kg6NU1Q"
-                  ],
-                  "payload": {
-                    "user": "theory",
-                    "date": "2024-07-20T20:34:34Z",
-                    "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
-                    "digests": {
-                      "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
-                    }
-                  }
-                }}),
-                "'/release': missing properties 'headers'",
+                  ]
+                }}}),
+                "'/certs/pgxn': missing properties 'payload'",
             ),
             (
-                "missing user",
-                json!({"release": {
-                  "headers": ["eyJhbGciOiJFUzI1NiJ9"],
-                  "signatures": [
-                    "DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSApmWQxfKTUJqPP3-Kg6NU1Q"
-                  ],
-                  "payload": {
-                    "date": "2024-07-20T20:34:34Z",
-                    "uri": "dist/semver/0.40.0/semver-0.40.0.zip",
-                    "digests": {
-                      "sha1": "fe8c013f991b5f537c39fb0c0b04bc955457675a"
-                    }
-                  }
-                }}),
-                "missing properties 'user'",
+                "missing signatures",
+                json!({"certs": {"pgxn": {
+                  "payload": "eyJ1c2VyIjoidGhlb3J5IiwiZGF0ZSI6IjIwMjQtMDktMTNUMTc6MzI6NTVaIiwidXJpIjoiZGlzdC9wYWlyLzAuMS43L3BhaXItMC4xLjcuemlwIiwiZGlnZXN0cyI6eyJzaGE1MTIiOiJiMzUzYjVhODJiM2I1NGU5NWY0YTI4NTllN2EyYmQwNjQ4YWJjYjM1YTdjMzYxMmIxMjZjMmM3NTQzOGZjMmY4ZThlZTFmMTllNjFmMzBmYTU0ZDdiYjY0YmNmMjE3ZWQxMjY0NzIyYjQ5N2JjYjYxM2Y4MmQ3ODc1MTUxNWI2NyJ9fQ",
+                }}}),
+                "'/certs/pgxn': missing properties 'signatures'",
             ),
         ] {
-            // Merge the release metadata; the release schema should validate it.
+            // Merge the certs metadata; the release schema should validate it.
             let mut meta = valid_v2_distribution();
-            json_patch::merge(&mut meta, &release_meta);
+            json_patch::merge(&mut meta, &certs_meta);
             match schemas.validate(&meta, release_idx) {
                 Err(e) => assert!(e.to_string().contains(err), "{name} Error: {e}"),
                 Ok(_) => panic!("{name} unexpectedly succeeded"),


### PR DESCRIPTION
Add the `certs` field to the `Release` struct and modify the `release` field to contain `ReleasePayload` parsed from the `pgxn` field of the `certs` hash map. Since the `release` field does not exist in the JSON, add custom deserialization to the `Release` struct that parses only the `dist` and `certs` fields and then extracts the `pgxn` JWS data and validates its base64-encoded JSON payload. No JWS validation yet, as the key management has not yet been worked out.

Revise the `v1_to_v2_release` method to build an appropriate Base 64-encoded payload and mock signature from v1 release metadata. Add tests to ensure that the keys are included in the JSON in unicode code point order (alphabetical, since it's all lowercase ASCII) and that there are no spaces.

Update the release tests for the new properties as well as the `certs` JSON schema.