### PR TITLE
Add error module and wrap all valid module errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ All notable changes to this project will be documented in this file. It uses the
   [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
     "Semantic Versioning 2.0.0"
 
+## [v0.5.0] — Unreleased
+
+### ⚡ Improvements
+
+*   Added the [error module], which defines all the errors returned by
+    pgxn_meta.
+*   Changed the errors returned from the [valid module] from boxed
+    [boon] errors with lifetimes to [error module] errors with no lifetimes.
+
+### 📔 Notes
+
+*   Removed the `valid::ValidationError` enum.
+
+  [v0.5.0]: https://github.com/pgxn/meta/compare/v0.4.0...v0.5.0
+  [error module]: https://docs.rs/pgxn_meta/0.5.0/pgxn_meta/error/
+  [valid module]: https://docs.rs/pgxn_meta/0.5.0/pgxn_meta/valid/
+  [boon]: https://github.com/santhosh-tekuri/boon
+
 ## [v0.4.0] — 2024-10-08
 
 The theme of this release is *JSON Web Signatures.*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,6 +508,7 @@ dependencies = [
  "serde_with",
  "spdx",
  "tempfile",
+ "thiserror",
  "wax",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 serde_with = { version = "3.9.0", features = ["hex"] }
 spdx = "0.10.6"
+thiserror = "1.0"
 wax = "0.6.0"
 
 [build-dependencies]

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -1,0 +1,60 @@
+//! PGXN Meta Errors.
+
+#[cfg(test)]
+mod tests;
+
+/// Build errors.
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// License Error.
+    #[error("{}", .0.reason)]
+    License(#[from] spdx::error::ParseError),
+
+    /// Validator cannot determine the version of the meta spec.
+    #[error("Cannot determine meta-spec version")]
+    UnknownSpec,
+
+    /// A schema file has no `$id` property.
+    #[error("No $id found in schema")]
+    UnknownSchemaId,
+
+    /// JSON Schema compile error.
+    #[error(transparent)]
+    #[allow(clippy::enum_variant_names)]
+    CompileError(#[from] boon::CompileError),
+
+    /// JSON Schema validation error.
+    #[error("{0}")]
+    #[allow(clippy::enum_variant_names)]
+    ValidationError(String),
+
+    /// Serde JSON error.
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+
+    /// IO error.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    /// Glob build error.
+    #[error(transparent)]
+    Glob(#[from] wax::GlobError),
+}
+
+impl<'s, 'v> From<boon::ValidationError<'s, 'v>> for Error {
+    fn from(value: boon::ValidationError<'s, 'v>) -> Self {
+        Self::ValidationError(value.to_string())
+    }
+}
+
+impl From<wax::BuildError> for Error {
+    fn from(value: wax::BuildError) -> Self {
+        wax::GlobError::Build(value).into()
+    }
+}
+
+impl From<wax::WalkError> for Error {
+    fn from(value: wax::WalkError) -> Self {
+        wax::GlobError::Walk(value).into()
+    }
+}

--- a/src/error/tests.rs
+++ b/src/error/tests.rs
@@ -1,0 +1,91 @@
+use super::*;
+use serde_json::json;
+
+#[test]
+fn spdx() {
+    let parse_error = spdx::Expression::parse("not a license").unwrap_err();
+    let exp = parse_error.reason.to_string();
+    let not_exp = parse_error.to_string();
+    let err: Error = parse_error.into();
+    assert!(matches!(err, Error::License { .. }));
+    assert_eq!(exp, err.to_string());
+    assert_ne!(not_exp, err.to_string());
+}
+
+#[test]
+fn unknown_spec() {
+    assert_eq!(
+        Error::UnknownSpec.to_string(),
+        "Cannot determine meta-spec version"
+    )
+}
+
+#[test]
+fn unknown_schema_id() {
+    assert_eq!(Error::UnknownSchemaId.to_string(), "No $id found in schema")
+}
+
+#[test]
+fn compile() {
+    let mut c = boon::Compiler::new();
+    c.add_resource("foo", json!("not a schema")).unwrap();
+    let mut s = boon::Schemas::new();
+    let compile_err = c.compile("foo", &mut s).unwrap_err();
+    let exp = compile_err.to_string();
+    let err: Error = compile_err.into();
+    assert!(matches!(err, Error::CompileError { .. }));
+    assert_eq!(exp, err.to_string(),);
+}
+
+#[test]
+fn validation() {
+    let mut c = boon::Compiler::new();
+    c.add_resource("foo", json!({"type": "object"})).unwrap();
+    let mut s = boon::Schemas::new();
+    let idx = c.compile("foo", &mut s).unwrap();
+    let json = json!([]);
+    let valid_err = s.validate(&json, idx).unwrap_err();
+    let exp = valid_err.to_string();
+    let err: Error = valid_err.into();
+    assert!(matches!(err, Error::ValidationError { .. }));
+    assert_eq!(exp, err.to_string());
+}
+
+#[test]
+fn serde() {
+    let serde_err = serde_json::from_str::<String>("[]").unwrap_err();
+    let exp = serde_err.to_string();
+    let err: Error = serde_err.into();
+    assert!(matches!(err, Error::Serde { .. }));
+    assert_eq!(exp, err.to_string());
+}
+
+#[test]
+fn io() {
+    use std::io;
+    let io_error = io::Error::new(io::ErrorKind::Other, "oh no!");
+    let exp = io_error.to_string();
+    let err: Error = io_error.into();
+    assert!(matches!(err, Error::Io { .. }));
+    assert_eq!(exp, err.to_string());
+}
+
+#[test]
+fn glob() {
+    let build_err = wax::Glob::new("[].json").unwrap_err();
+    let exp = build_err.to_string();
+    let err: Error = build_err.into();
+    assert!(matches!(err, Error::Glob { .. }));
+    assert_eq!(exp, err.to_string());
+
+    let glob = wax::Glob::new("*.json").unwrap();
+    for path in glob.walk("nonesuch 😇") {
+        // Would be nice to just fetch the first, but should always be an
+        // error anyway.
+        let walk_err = path.unwrap_err();
+        let exp = walk_err.to_string();
+        let err: Error = walk_err.into();
+        assert!(matches!(err, Error::Glob { .. }));
+        assert_eq!(exp, err.to_string());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ files. It supports both the [v1] and [v2] specs.
 */
 
 pub mod dist;
+pub mod error;
 pub mod release;
 mod util; // private utilities
 pub mod valid;


### PR DESCRIPTION
Add the `error` module, defining an Error enum using `thiserror`. Create variants for all of the errors generated by the `valid` module, and replace its custom `ValidationError` enum. Includes tests for each variant. Then teach that module to return only our errors. 

Note the special treatment for these error conversions:

*   `boon::ValidationError`s use lifetimes to hang on to values from the boon compiler and from the JSON that fails validation. This makes it quite tricky to use separate from those values. But since, so far, we just want to print JSON Schema validation errors, add a `From` trait implementation that simply copies its string value into our error type. This allows all the lifetime annotations to be removed from the `valid` crate.

*   `wax::GlobError` is an enum that wraps the two types that the `wax` create generates. To coerce those two types, add a `From` trait for each.

While at it, improve the error generation for the custom `license` format so that the error message generated by boon is more legible and useful. Previously it just showed the value that failed --- twice --- but now it also shows the "reason" for the error.

Also: change the behavior of `is_license` and `is_path` to return `Ok(())` if the value is not a string, following the example of the format validation functions in boon itself. New tests for the `license` and `path` custom formats validate the usability of the error messages.