### PR TITLE
Replace dist errors

### DIFF
--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -8,9 +8,9 @@ distribution `META.json` files. It supports both the [v1] and [v2] specs.
   [v2]: https://github.com/pgxn/rfcs/pull/3
 
 */
-use std::{borrow::Borrow, collections::HashMap, error::Error, fs::File, path::Path};
+use std::{borrow::Borrow, collections::HashMap, fs::File, path::Path};
 
-use crate::util;
+use crate::{error::Error, util};
 use relative_path::{RelativePath, RelativePathBuf};
 use semver::Version;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -828,18 +828,18 @@ where
 impl Distribution {
     /// Deserializes `meta`, which contains PGXN `version` metadata, into a
     /// [`Distribution`].
-    fn from_version(version: u8, meta: Value) -> Result<Self, Box<dyn Error>> {
+    fn from_version(version: u8, meta: Value) -> Result<Self, Error> {
         match version {
             1 => v1::from_value(meta),
             2 => v2::from_value(meta),
-            _ => Err(Box::from(format!("Unknown meta version {version}"))),
+            _ => Err(Error::UnknownSpec),
         }
     }
 
     /// Loads the release `META.json` data from `file` then converts into a
     /// [`Distribution`]. Returns an error on file error or if the content of
     /// `file` is not valid PGXN `META.json` data.
-    pub fn load<P: AsRef<Path>>(file: P) -> Result<Self, Box<dyn Error>> {
+    pub fn load<P: AsRef<Path>>(file: P) -> Result<Self, Error> {
         let meta: Value = serde_json::from_reader(File::open(file)?)?;
         meta.try_into()
     }
@@ -922,7 +922,7 @@ impl Distribution {
 }
 
 impl TryFrom<Value> for Distribution {
-    type Error = Box<dyn Error>;
+    type Error = Error;
     /// Converts the PGXN `META.json` data from `meta` into a
     /// [`Distribution`]. Returns an error if `meta` is invalid.
     ///
@@ -959,16 +959,13 @@ impl TryFrom<Value> for Distribution {
     fn try_from(meta: Value) -> Result<Self, Self::Error> {
         // Make sure it's valid.
         let mut validator = crate::valid::Validator::new();
-        let version = match validator.validate(&meta) {
-            Err(e) => return Err(Box::from(e.to_string())),
-            Ok(v) => v,
-        };
+        let version = validator.validate(&meta)?;
         Distribution::from_version(version, meta)
     }
 }
 
 impl TryFrom<&[&Value]> for Distribution {
-    type Error = Box<dyn Error>;
+    type Error = Error;
     /// Merge multiple PGXN `META.json` data from `meta` into a
     /// [`Distribution`]. Returns an error if `meta` is invalid.
     ///
@@ -1013,12 +1010,11 @@ impl TryFrom<&[&Value]> for Distribution {
     /// [RFC 7396]: https:///www.rfc-editor.org/rfc/rfc7396.html
     fn try_from(meta: &[&Value]) -> Result<Self, Self::Error> {
         if meta.is_empty() {
-            return Err(Box::from("meta contains no values"));
+            return Err(Error::Param("meta contains no values"));
         }
 
         // Find the version of the first doc.
-        let version =
-            util::get_version(meta[0]).ok_or("No spec version found in first meta value")?;
+        let version = util::get_version(meta[0]).ok_or(Error::UnknownSpec)?;
 
         // Convert the first doc to v2 if necessary.
         let mut v2 = match version {
@@ -1034,21 +1030,20 @@ impl TryFrom<&[&Value]> for Distribution {
 
         // Validate the patched doc and return.
         let mut validator = crate::valid::Validator::new();
-        validator.validate(&v2).map_err(|e| e.to_string())?;
+        validator.validate(&v2)?;
         Distribution::from_version(2, v2)
     }
 }
 
 impl TryFrom<Distribution> for Value {
-    type Error = Box<dyn Error>;
+    type Error = Error;
     /// Converts `meta` into a [serde_json::Value].
     ///
     /// # Example
     ///
     /// ``` rust
-    /// # use std::error::Error;
     /// use serde_json::{json, Value};
-    /// use pgxn_meta::dist::*;
+    /// use pgxn_meta::{error::Error, dist::*};
     ///
     /// let meta_json = json!({
     ///   "name": "pair",
@@ -1072,7 +1067,7 @@ impl TryFrom<Distribution> for Value {
     ///
     /// let meta = Distribution::try_from(meta_json);
     /// assert!(meta.is_ok());
-    /// let val: Result<Value, Box<dyn Error>> = meta.unwrap().try_into();
+    /// let val: Result<Value, Error> = meta.unwrap().try_into();
     /// assert!(val.is_ok());
     /// ```
     fn try_from(meta: Distribution) -> Result<Self, Self::Error> {
@@ -1082,7 +1077,7 @@ impl TryFrom<Distribution> for Value {
 }
 
 impl TryFrom<&String> for Distribution {
-    type Error = Box<dyn Error>;
+    type Error = Error;
     /// Converts `str` into JSON and then into  a [`Distribution`]. Returns an
     /// error if the content of `str` is not valid PGXN `META.json` data.
     fn try_from(str: &String) -> Result<Self, Self::Error> {
@@ -1092,7 +1087,7 @@ impl TryFrom<&String> for Distribution {
 }
 
 impl TryFrom<Distribution> for String {
-    type Error = Box<dyn Error>;
+    type Error = Error;
     /// Converts `meta` into a JSON String.
     fn try_from(meta: Distribution) -> Result<Self, Self::Error> {
         let val = serde_json::to_string(&meta)?;

--- a/src/dist/v1/tests.rs
+++ b/src/dist/v1/tests.rs
@@ -116,22 +116,22 @@ fn test_v1_to_v2_maintainers_errors() {
         (
             "null maintainer",
             json!({"maintainer": null}),
-            "Invalid v1 maintainer: null",
+            "invalid v1 maintainer value: null",
         ),
         (
             "object maintainer",
             json!({"maintainer": {"name": "hi"}}),
-            r#"Invalid v1 maintainer: {"name":"hi"}"#,
+            r#"invalid v1 maintainer value: {"name":"hi"}"#,
         ),
         (
             "null maintainer item",
             json!({"maintainer": [null]}),
-            "Invalid v1 maintainer: null",
+            "invalid v1 maintainer value: null",
         ),
         (
             "true maintainer item",
             json!({"maintainer": [true]}),
-            "Invalid v1 maintainer: true",
+            "invalid v1 maintainer value: true",
         ),
     ] {
         match v1_to_v2_maintainers(&input) {
@@ -249,25 +249,33 @@ fn test_v1_v2_licenses_error() {
         (
             "unknown string",
             json!({"license": "nonesuch"}),
-            "Invalid v1 license: \"nonesuch\"",
+            "invalid v1 license value: \"nonesuch\"",
         ),
         (
             "unknown array",
             json!({"license": ["nonesuch"]}),
-            "Invalid v1 license: \"nonesuch\"",
+            "invalid v1 license value: \"nonesuch\"",
         ),
         (
             "array non-string item",
             json!({"license": [{"x": "y"}]}),
-            "Invalid v1 license: {\"x\":\"y\"}",
+            "invalid v1 license value: {\"x\":\"y\"}",
         ),
         (
             "unknown object",
             json!({"license": {"nonesuch": "http://example.com"}}),
-            "Unknown v1 license: nonesuch: \"http://example.com\"",
+            "invalid v1 license value: \"http://example.com\"",
         ),
-        ("number", json!({"license": 42}), "Invalid v1 license: 42"),
-        ("null", json!({"license": null}), "Invalid v1 license: null"),
+        (
+            "number",
+            json!({"license": 42}),
+            "invalid v1 license value: 42",
+        ),
+        (
+            "null",
+            json!({"license": null}),
+            "invalid v1 license value: null",
+        ),
         ("nonexistent", json!({}), "license property missing"),
     ] {
         match v1_to_v2_license(&input) {
@@ -333,12 +341,12 @@ fn test_v1_v2_contents_err() {
         (
             "provides null",
             json!({"provides": null}),
-            "Invalid v1 provides value: null",
+            "invalid v1 provides value: null",
         ),
         (
             "extension not object",
             json!({"provides": {"foo": []}}),
-            "Invalid v1 \"foo\" extension value: []",
+            "invalid v1 extension value: []",
         ),
     ] {
         match v1_to_v2_contents(&input) {
@@ -678,7 +686,7 @@ fn test_v1_v2_resources() {
 }
 
 #[test]
-fn test_from_value() -> Result<(), Box<dyn Error>> {
+fn test_from_value() -> Result<(), Error> {
     use wax::Glob;
     let dir: PathBuf = [env!("CARGO_MANIFEST_DIR"), "corpus", "v1"]
         .iter()

--- a/src/dist/v2/mod.rs
+++ b/src/dist/v2/mod.rs
@@ -1,10 +1,7 @@
 use super::Distribution;
+use crate::error::Error;
 use serde_json::Value;
-use std::error::Error;
 
-pub fn from_value(meta: Value) -> Result<Distribution, Box<dyn Error>> {
-    match serde_json::from_value(meta) {
-        Ok(m) => Ok(m),
-        Err(e) => Err(Box::from(e)),
-    }
+pub fn from_value(meta: Value) -> Result<Distribution, Error> {
+    Ok(serde_json::from_value(meta)?)
 }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -11,11 +11,11 @@ pub enum Error {
     License(#[from] spdx::error::ParseError),
 
     /// Validator cannot determine the version of the meta spec.
-    #[error("Cannot determine meta-spec version")]
+    #[error("cannot determine meta-spec version")]
     UnknownSpec,
 
     /// A schema file has no `$id` property.
-    #[error("No $id found in schema")]
+    #[error("no $id found in schema")]
     UnknownSchemaId,
 
     /// JSON Schema compile error.
@@ -39,6 +39,18 @@ pub enum Error {
     /// Glob build error.
     #[error(transparent)]
     Glob(#[from] wax::GlobError),
+
+    /// Parameter errors.
+    #[error("{0}")]
+    Param(&'static str),
+
+    /// Invalid property value.
+    #[error("invalid v{1} {0} value: {2}")]
+    Invalid(&'static str, u8, serde_json::Value),
+
+    /// Missing property value.
+    #[error("{0} property missing")]
+    Missing(&'static str),
 }
 
 impl<'s, 'v> From<boon::ValidationError<'s, 'v>> for Error {

--- a/src/error/tests.rs
+++ b/src/error/tests.rs
@@ -16,13 +16,13 @@ fn spdx() {
 fn unknown_spec() {
     assert_eq!(
         Error::UnknownSpec.to_string(),
-        "Cannot determine meta-spec version"
+        "cannot determine meta-spec version"
     )
 }
 
 #[test]
 fn unknown_schema_id() {
-    assert_eq!(Error::UnknownSchemaId.to_string(), "No $id found in schema")
+    assert_eq!(Error::UnknownSchemaId.to_string(), "no $id found in schema")
 }
 
 #[test]
@@ -88,4 +88,35 @@ fn glob() {
         assert!(matches!(err, Error::Glob { .. }));
         assert_eq!(exp, err.to_string());
     }
+}
+
+#[test]
+fn parameter() {
+    assert_eq!("invalid hi", Error::Param("invalid hi").to_string())
+}
+
+#[test]
+fn invalid() {
+    for (name, err, exp) in [
+        (
+            "v1 thing",
+            Error::Invalid("thing", 1, json!("hi")),
+            "invalid v1 thing value: \"hi\"",
+        ),
+        (
+            "v2 bag array",
+            Error::Invalid("bag", 2, json!([])),
+            "invalid v2 bag value: []",
+        ),
+    ] {
+        assert_eq!(exp, err.to_string(), "{name}");
+    }
+}
+
+#[test]
+fn missing() {
+    assert_eq!(
+        "thing property missing",
+        Error::Missing("thing").to_string()
+    )
 }

--- a/src/release/tests.rs
+++ b/src/release/tests.rs
@@ -177,7 +177,7 @@ fn test_bad_corpus() -> Result<(), Box<dyn Error>> {
     meta.as_object_mut().unwrap().remove("meta-spec");
     match Release::try_from(meta.clone()) {
         Ok(_) => panic!("Unexpected success with no meta-spec"),
-        Err(e) => assert_eq!("Cannot determine meta-spec version", e.to_string()),
+        Err(e) => assert_eq!("cannot determine meta-spec version", e.to_string()),
     }
 
     // Should fail on missing certs object.

--- a/src/valid/mod.rs
+++ b/src/valid/mod.rs
@@ -222,7 +222,7 @@ mod tests {
         ] {
             match validator.validate(&json) {
                 Err(e) => assert_eq!(
-                    "Cannot determine meta-spec version",
+                    "cannot determine meta-spec version",
                     e.to_string(),
                     "{name} validate"
                 ),
@@ -230,7 +230,7 @@ mod tests {
             }
             match validator.validate_release(&json) {
                 Err(e) => assert_eq!(
-                    "Cannot determine meta-spec version",
+                    "cannot determine meta-spec version",
                     e.to_string(),
                     "{name} validate_release"
                 ),


### PR DESCRIPTION
Add property validation and parameter errors to the error module and replace all `Box<Error>`s in the dist module with `error:Error`s.

Also, make the first word of all error messages consistently lowercase.