### PR TITLE
Replace remaining errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,14 @@ All notable changes to this project will be documented in this file. It uses the
 
 *   Added the [error module], which defines all the errors returned by
     pgxn_meta.
-*   Changed the errors returned from the [valid module] from boxed
-    [boon] errors with lifetimes to [error module] errors with no lifetimes.
+*   Changed the errors returned by all the APIs from boxed errors [error
+    module] errors.
 
 ### 📔 Notes
 
 *   Removed the `valid::ValidationError` enum.
+*   Changed the errors returned from the [valid module] from boxed [boon]
+    errors with lifetimes to [error module] errors with no lifetimes.
 
   [v0.5.0]: https://github.com/pgxn/meta/compare/v0.4.0...v0.5.0
   [error module]: https://docs.rs/pgxn_meta/0.5.0/pgxn_meta/error/

--- a/src/release/v1/tests.rs
+++ b/src/release/v1/tests.rs
@@ -87,7 +87,7 @@ fn test_v1_v2_release_err() {
         match v1_to_v2_release(&input) {
             Ok(_) => panic!("{name} unexpectedly succeeded"),
             Err(e) => assert_eq!(
-                format!("missing release property \"{name}\""),
+                format!("{name} property missing"),
                 e.to_string(),
                 "{name}: {e}"
             ),

--- a/src/release/v2/mod.rs
+++ b/src/release/v2/mod.rs
@@ -1,10 +1,7 @@
 use super::Release;
+use crate::error::Error;
 use serde_json::Value;
-use std::error::Error;
 
-pub fn from_value(meta: Value) -> Result<Release, Box<dyn Error>> {
-    match serde_json::from_value(meta) {
-        Ok(m) => Ok(m),
-        Err(e) => Err(Box::from(e)),
-    }
+pub fn from_value(meta: Value) -> Result<Release, Error> {
+    Ok(serde_json::from_value(meta)?)
 }

--- a/src/tests/common.rs
+++ b/src/tests/common.rs
@@ -1,11 +1,10 @@
 use std::{
     collections::HashMap,
-    error::Error,
     fs::{self, File},
     path::Path,
 };
 
-use crate::valid::compiler;
+use crate::{error::Error, valid::compiler};
 use boon::{Compiler, Schemas};
 use serde_json::{json, Value};
 use wax::Glob;
@@ -93,22 +92,20 @@ pub fn id_for(version: u8, schema: &str) -> String {
     format!("{SCHEMA_BASE}{version}/{schema}.schema.json")
 }
 
-pub fn new_compiler<P: AsRef<Path>>(dir: P) -> Result<Compiler, Box<dyn Error>> {
+pub fn new_compiler<P: AsRef<Path>>(dir: P) -> Result<Compiler, Error> {
     let mut compiler = compiler::spec_compiler();
     let glob = Glob::new("**/*.schema.json")?;
     for path in glob.walk(dir) {
         let path = path?.into_path();
         let schema: Value = serde_json::from_reader(File::open(&path)?)?;
-        let id = &schema["$id"]
-            .as_str()
-            .ok_or(format!("Missing $id from {}", &path.display()))?;
+        let id = &schema["$id"].as_str().ok_or(Error::UnknownSchemaId)?;
         compiler.add_resource(id, schema.to_owned())?;
     }
 
     Ok(compiler)
 }
 
-pub fn test_term_schema(mut compiler: Compiler, version: u8) -> Result<(), Box<dyn Error>> {
+pub fn test_term_schema(mut compiler: Compiler, version: u8) -> Result<(), Error> {
     let mut schemas = Schemas::new();
     let id = id_for(version, "term");
     let idx = compiler.compile(&id, &mut schemas)?;
@@ -157,7 +154,7 @@ pub fn test_term_schema(mut compiler: Compiler, version: u8) -> Result<(), Box<d
     Ok(())
 }
 
-pub fn test_tags_schema(mut compiler: Compiler, version: u8) -> Result<(), Box<dyn Error>> {
+pub fn test_tags_schema(mut compiler: Compiler, version: u8) -> Result<(), Error> {
     // Load the schemas and compile the tags schema.
     let mut schemas = Schemas::new();
     let id = id_for(version, "tags");
@@ -206,7 +203,7 @@ pub fn test_tags_schema(mut compiler: Compiler, version: u8) -> Result<(), Box<d
     Ok(())
 }
 
-pub fn test_schema_version(version: u8) -> Result<(), Box<dyn Error>> {
+pub fn test_schema_version(version: u8) -> Result<(), Error> {
     let mut compiler = Compiler::new();
     compiler.enable_format_assertions();
     let mut loaded: HashMap<String, Vec<Value>> = HashMap::new();

--- a/src/tests/v1.rs
+++ b/src/tests/v1.rs
@@ -1,34 +1,31 @@
-use std::error::Error;
-
+use super::common::*;
+use crate::error::Error;
 use boon::Schemas;
 use serde_json::{json, Map, Value};
-
-// importing common module.
-use super::common::*;
 
 const SCHEMA_VERSION: u8 = 1;
 
 #[test]
-fn test_schema_v1() -> Result<(), Box<dyn Error>> {
+fn test_schema_v1() -> Result<(), Error> {
     test_schema_version(SCHEMA_VERSION)
 }
 
 #[test]
-fn test_v1_term() -> Result<(), Box<dyn Error>> {
+fn test_v1_term() -> Result<(), Error> {
     // Load the schemas and compile the term schema.
     let compiler = new_compiler("schema/v1")?;
     test_term_schema(compiler, SCHEMA_VERSION)
 }
 
 #[test]
-fn test_v1_tags() -> Result<(), Box<dyn Error>> {
+fn test_v1_tags() -> Result<(), Error> {
     // Load the schemas and compile the tags schema.
     let compiler = new_compiler("schema/v1")?;
     test_tags_schema(compiler, SCHEMA_VERSION)
 }
 
 #[test]
-fn test_v1_version() -> Result<(), Box<dyn Error>> {
+fn test_v1_version() -> Result<(), Error> {
     // Load the schemas and compile the version schema.
     let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
@@ -53,7 +50,7 @@ fn test_v1_version() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v1_version_range() -> Result<(), Box<dyn Error>> {
+fn test_v1_version_range() -> Result<(), Error> {
     // Load the schemas and compile the version_range schema.
     let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
@@ -124,7 +121,7 @@ fn test_v1_version_range() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v1_license() -> Result<(), Box<dyn Error>> {
+fn test_v1_license() -> Result<(), Error> {
     // Load the schemas and compile the license schema.
     let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
@@ -193,7 +190,7 @@ fn test_v1_license() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v1_provides() -> Result<(), Box<dyn Error>> {
+fn test_v1_provides() -> Result<(), Error> {
     // Load the schemas and compile the provides schema.
     let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
@@ -292,7 +289,7 @@ fn test_v1_provides() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v1_extension() -> Result<(), Box<dyn Error>> {
+fn test_v1_extension() -> Result<(), Error> {
     // Load the schemas and compile the extension schema.
     let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
@@ -468,7 +465,7 @@ fn test_v1_extension() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v1_maintainer() -> Result<(), Box<dyn Error>> {
+fn test_v1_maintainer() -> Result<(), Error> {
     // Load the schemas and compile the maintainer schema.
     let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
@@ -518,7 +515,7 @@ fn test_v1_maintainer() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v1_meta_spec() -> Result<(), Box<dyn Error>> {
+fn test_v1_meta_spec() -> Result<(), Error> {
     // Load the schemas and compile the maintainer schema.
     let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
@@ -576,7 +573,7 @@ fn test_v1_meta_spec() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v1_bugtracker() -> Result<(), Box<dyn Error>> {
+fn test_v1_bugtracker() -> Result<(), Error> {
     // Load the schemas and compile the maintainer schema.
     let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
@@ -630,7 +627,7 @@ fn test_v1_bugtracker() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v1_no_index() -> Result<(), Box<dyn Error>> {
+fn test_v1_no_index() -> Result<(), Error> {
     // Load the schemas and compile the maintainer schema.
     let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
@@ -697,7 +694,7 @@ fn test_v1_no_index() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v1_prereq_relationship() -> Result<(), Box<dyn Error>> {
+fn test_v1_prereq_relationship() -> Result<(), Error> {
     // Load the schemas and compile the maintainer schema.
     let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
@@ -750,7 +747,7 @@ fn test_v1_prereq_relationship() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v1_prereq_phase() -> Result<(), Box<dyn Error>> {
+fn test_v1_prereq_phase() -> Result<(), Error> {
     // Load the schemas and compile the maintainer schema.
     let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
@@ -862,7 +859,7 @@ fn test_v1_prereq_phase() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v1_prereqs() -> Result<(), Box<dyn Error>> {
+fn test_v1_prereqs() -> Result<(), Error> {
     // Load the schemas and compile the maintainer schema.
     let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
@@ -1010,7 +1007,7 @@ fn test_v1_prereqs() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v1_repository() -> Result<(), Box<dyn Error>> {
+fn test_v1_repository() -> Result<(), Error> {
     // Load the schemas and compile the repository schema.
     let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
@@ -1087,7 +1084,7 @@ fn test_v1_repository() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v1_resources() -> Result<(), Box<dyn Error>> {
+fn test_v1_resources() -> Result<(), Error> {
     // Load the schemas and compile the resources schema.
     let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
@@ -1224,7 +1221,7 @@ fn valid_distribution() -> Value {
 }
 
 #[test]
-fn test_v1_distribution() -> Result<(), Box<dyn Error>> {
+fn test_v1_distribution() -> Result<(), Error> {
     // Load the schemas and compile the distribution schema.
     let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();
@@ -2043,7 +2040,7 @@ fn test_v1_distribution() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v1_release() -> Result<(), Box<dyn Error>> {
+fn test_v1_release() -> Result<(), Error> {
     // Load the schemas and compile the distribution schema.
     let mut compiler = new_compiler("schema/v1")?;
     let mut schemas = Schemas::new();

--- a/src/tests/v2.rs
+++ b/src/tests/v2.rs
@@ -1,32 +1,29 @@
-use std::error::Error;
-
+use super::common::*;
+use crate::error::Error;
 use boon::Schemas;
 use serde_json::{json, Map, Value};
-
-// importing common module.
-use super::common::*;
 
 const SCHEMA_VERSION: u8 = 2;
 
 #[test]
-fn test_schema_v2() -> Result<(), Box<dyn Error>> {
+fn test_schema_v2() -> Result<(), Error> {
     test_schema_version(SCHEMA_VERSION)
 }
 
 #[test]
-fn test_v2_term() -> Result<(), Box<dyn Error>> {
+fn test_v2_term() -> Result<(), Error> {
     let compiler = new_compiler("schema/v2")?;
     test_term_schema(compiler, SCHEMA_VERSION)
 }
 
 #[test]
-fn test_v2_tags() -> Result<(), Box<dyn Error>> {
+fn test_v2_tags() -> Result<(), Error> {
     let compiler = new_compiler("schema/v2")?;
     test_tags_schema(compiler, SCHEMA_VERSION)
 }
 
 #[test]
-fn test_v2_semver() -> Result<(), Box<dyn Error>> {
+fn test_v2_semver() -> Result<(), Error> {
     // Load the schemas and compile the semver schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -56,7 +53,7 @@ fn test_v2_semver() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_path() -> Result<(), Box<dyn Error>> {
+fn test_v2_path() -> Result<(), Error> {
     // Load the schemas and compile the path schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -100,7 +97,7 @@ fn test_v2_path() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_glob() -> Result<(), Box<dyn Error>> {
+fn test_v2_glob() -> Result<(), Error> {
     // Load the schemas and compile the glob schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -141,7 +138,7 @@ fn test_v2_glob() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_version_range() -> Result<(), Box<dyn Error>> {
+fn test_v2_version_range() -> Result<(), Error> {
     // Load the schemas and compile the version_range schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -211,7 +208,7 @@ fn test_v2_version_range() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_license() -> Result<(), Box<dyn Error>> {
+fn test_v2_license() -> Result<(), Error> {
     // Load the schemas and compile the license schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -261,7 +258,7 @@ fn test_v2_license() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_purl() -> Result<(), Box<dyn Error>> {
+fn test_v2_purl() -> Result<(), Error> {
     // Load the schemas and compile the purl schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -305,7 +302,7 @@ fn test_v2_purl() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_platform() -> Result<(), Box<dyn Error>> {
+fn test_v2_platform() -> Result<(), Error> {
     // Load the schemas and compile the platform schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -391,7 +388,7 @@ fn test_v2_platform() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_platforms() -> Result<(), Box<dyn Error>> {
+fn test_v2_platforms() -> Result<(), Error> {
     // Load the schemas and compile the platforms schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -439,7 +436,7 @@ fn test_v2_platforms() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_maintainers() -> Result<(), Box<dyn Error>> {
+fn test_v2_maintainers() -> Result<(), Error> {
     // Load the schemas and compile the maintainers schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -577,7 +574,7 @@ fn test_v2_maintainers() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_extension() -> Result<(), Box<dyn Error>> {
+fn test_v2_extension() -> Result<(), Error> {
     // Load the schemas and compile the extension schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -754,7 +751,7 @@ fn test_v2_extension() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_module() -> Result<(), Box<dyn Error>> {
+fn test_v2_module() -> Result<(), Error> {
     // Load the schemas and compile the module schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -923,7 +920,7 @@ fn test_v2_module() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_app() -> Result<(), Box<dyn Error>> {
+fn test_v2_app() -> Result<(), Error> {
     // Load the schemas and compile the app schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -1037,7 +1034,7 @@ fn test_v2_app() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_contents() -> Result<(), Box<dyn Error>> {
+fn test_v2_contents() -> Result<(), Error> {
     // Load the schemas and compile the contents schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -1176,7 +1173,7 @@ fn test_v2_contents() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_meta_spec() -> Result<(), Box<dyn Error>> {
+fn test_v2_meta_spec() -> Result<(), Error> {
     // Load the schemas and compile the meta-spec schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -1230,7 +1227,7 @@ fn test_v2_meta_spec() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_categories() -> Result<(), Box<dyn Error>> {
+fn test_v2_categories() -> Result<(), Error> {
     // Load the schemas and compile the categories schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -1299,7 +1296,7 @@ fn test_v2_categories() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_classifications() -> Result<(), Box<dyn Error>> {
+fn test_v2_classifications() -> Result<(), Error> {
     // Load the schemas and compile the classifications schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -1370,7 +1367,7 @@ fn test_v2_classifications() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_ignore() -> Result<(), Box<dyn Error>> {
+fn test_v2_ignore() -> Result<(), Error> {
     // Load the schemas and compile the ignore schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -1428,7 +1425,7 @@ fn test_v2_ignore() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_phase() -> Result<(), Box<dyn Error>> {
+fn test_v2_phase() -> Result<(), Error> {
     // Load the schemas and compile the phase schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -1555,7 +1552,7 @@ fn test_v2_phase() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_packages() -> Result<(), Box<dyn Error>> {
+fn test_v2_packages() -> Result<(), Error> {
     // Load the schemas and compile the packages schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -1709,7 +1706,7 @@ fn test_v2_packages() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_postgres() -> Result<(), Box<dyn Error>> {
+fn test_v2_postgres() -> Result<(), Error> {
     // Load the schemas and compile the postgres schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -1769,7 +1766,7 @@ fn test_v2_postgres() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_pipeline() -> Result<(), Box<dyn Error>> {
+fn test_v2_pipeline() -> Result<(), Error> {
     // Load the schemas and compile the pipeline schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -1813,7 +1810,7 @@ fn test_v2_pipeline() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_dependencies() -> Result<(), Box<dyn Error>> {
+fn test_v2_dependencies() -> Result<(), Error> {
     // Load the schemas and compile the dependencies schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -2068,7 +2065,7 @@ fn test_v2_dependencies() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_variations() -> Result<(), Box<dyn Error>> {
+fn test_v2_variations() -> Result<(), Error> {
     // Load the schemas and compile the variations schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -2198,7 +2195,7 @@ fn test_v2_variations() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_badges() -> Result<(), Box<dyn Error>> {
+fn test_v2_badges() -> Result<(), Error> {
     // Load the schemas and compile the badges schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -2311,7 +2308,7 @@ fn test_v2_badges() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_resources() -> Result<(), Box<dyn Error>> {
+fn test_v2_resources() -> Result<(), Error> {
     // Load the schemas and compile the resources schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -2437,7 +2434,7 @@ fn test_v2_resources() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_artifacts() -> Result<(), Box<dyn Error>> {
+fn test_v2_artifacts() -> Result<(), Error> {
     // Load the schemas and compile the artifacts schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -2810,7 +2807,7 @@ fn valid_v2_distribution() -> Value {
 }
 
 #[test]
-fn test_v2_distribution() -> Result<(), Box<dyn Error>> {
+fn test_v2_distribution() -> Result<(), Error> {
     // Load the schemas and compile the distribution schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -3261,7 +3258,7 @@ fn test_v2_distribution() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_digests() -> Result<(), Box<dyn Error>> {
+fn test_v2_digests() -> Result<(), Error> {
     // Load the schemas and compile the digests schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -3421,7 +3418,7 @@ fn test_v2_digests() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_payload() -> Result<(), Box<dyn Error>> {
+fn test_v2_payload() -> Result<(), Error> {
     // Load the schemas and compile the payload schema.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
@@ -3804,7 +3801,7 @@ fn test_v2_payload() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_jwk() -> Result<(), Box<dyn Error>> {
+fn test_v2_jwk() -> Result<(), Error> {
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "jwk");
@@ -3978,7 +3975,7 @@ fn test_v2_jwk() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_jws_header() -> Result<(), Box<dyn Error>> {
+fn test_v2_jws_header() -> Result<(), Error> {
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "jws-header");
@@ -4131,7 +4128,7 @@ fn test_v2_jws_header() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_jws() -> Result<(), Box<dyn Error>> {
+fn test_v2_jws() -> Result<(), Error> {
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "jws");
@@ -4692,7 +4689,7 @@ fn test_v2_jws() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_certs() -> Result<(), Box<dyn Error>> {
+fn test_v2_certs() -> Result<(), Error> {
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();
     let id = id_for(SCHEMA_VERSION, "certs");
@@ -4777,7 +4774,7 @@ fn test_v2_certs() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_v2_release() -> Result<(), Box<dyn Error>> {
+fn test_v2_release() -> Result<(), Error> {
     // Load the schemas and compile the release and distribution schemas.
     let mut compiler = new_compiler("schema/v2")?;
     let mut schemas = Schemas::new();


### PR DESCRIPTION
All the APIs now return errors from the error module in this crate. The only bits left that return boxed errors are:

*   The custom JSON Schema format validation functions in `src/valid/compiler/mod.rs`, which are required to be boxed errors by the boon crate.
*   `build.rs` and `main.rs`, where it seems harmless, since those errors are always printed ton the terminal.