### PR TITLE
Add `release.Digests.validate` method

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Disable line-ending conversion of JSON files, so that the hash digest
+# validation tests pass on Windows.
+*.json         -text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to this project will be documented in this file. It uses the
     pgxn_meta.
 *   Changed the errors returned by all the APIs from boxed errors [error
     module] errors.
+*   Added `release.Digests.validate` method to validate a file against one or
+    more digests.
 
 ### 📔 Notes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "boon"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,10 +177,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "darling"
@@ -216,6 +250,16 @@ checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
  "serde",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -277,6 +321,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -496,6 +550,8 @@ dependencies = [
  "base64 0.22.1",
  "boon",
  "chrono",
+ "constant_time_eq",
+ "digest",
  "email_address",
  "hex",
  "json-patch",
@@ -506,6 +562,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "sha1",
+ "sha2",
  "spdx",
  "tempfile",
  "thiserror",
@@ -722,6 +780,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,6 +917,12 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,10 @@ exclude = [ ".github", ".vscode", ".gitignore", ".ci", ".pre-*.yaml"]
 base64 = "0.22"
 boon = "0.6"
 chrono = { version = "0.4.38", features = ["serde"] }
+constant_time_eq = "0.3"
+digest = "0.10"
 email_address = "0.2.9"
+hex = "0.4"
 json-patch = "3.0"
 lexopt = "0.3.0"
 rand = "0.8.5"
@@ -27,6 +30,8 @@ semver = { version = "1.0", features = ["std", "serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 serde_with = { version = "3.9.0", features = ["hex"] }
+sha1 = "0.10"
+sha2 = "0.10"
 spdx = "0.10.6"
 thiserror = "1.0"
 wax = "0.6.0"
@@ -37,5 +42,4 @@ serde_json = "1.0"
 
 [dev-dependencies]
 assert-json-diff = "2.0.2"
-hex = "0.4.3"
 tempfile = "3.12.0"

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -51,6 +51,10 @@ pub enum Error {
     /// Missing property value.
     #[error("{0} property missing")]
     Missing(&'static str),
+
+    /// Hash digest mismatch.
+    #[error("{0} digest {1} does not match {2}")]
+    Digest(&'static str, String, String),
 }
 
 impl<'s, 'v> From<boon::ValidationError<'s, 'v>> for Error {


### PR DESCRIPTION
Validates a file path against one or more SHA digests. Uses the `sha1` and `sha2` crates, which are part of the [Rust Crypto] project. Uses the `constant_time_eq` crate to compare the values. A new `Digest` error variant reports digest mismatches, displaying them has hex strings.

Disable automatic line-ending conversion in JSON files to prevent test failures on Windows.


  [Rust Crypto]: https://github.com/RustCrypto