### PR TITLE
Extend release validation to support v1 API files

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,6 +14,7 @@ jobs:
   release:
     name: ${{ matrix.platform.emoji }} ${{ matrix.platform.os_name }} 🦀 ${{ matrix.toolchain }}
     runs-on: ${{ matrix.platform.os }}
+    continue-on-error: ${{ matrix.toolchain == 'nightly' }}
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file. It uses the
   [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
     "Semantic Versioning 2.0.0"
 
-## [v0.6.0] — Unreleased
+## [v0.6.0] — 2025-03-25
 
 ### ⬆️ Dependency Updates
 
@@ -17,13 +17,23 @@ All notable changes to this project will be documented in this file. It uses the
 
 *   Added basic logging for schema validation, digest validation, and JWS
     validation.
+*   Extended the v1 Release schema to include the properties added by the [API
+    Server Meta API]. However, these properties are not currently available
+    via accessors, as the v2 schema does not (yet) define equivalents.
+*   Improved validation of v1 schema paths to ensure they always use Unix
+    conventions and don't point to files outside a distribution.
 
-### 📔 Notes
+### 🏗️ Build Setup
 
-*   Upgraded [Cross] and and the Binary build workers.
+*   Upgraded [Cross] and and the binary build workers.
+*   Dropped the Solaris build pending [support for Solaris 11].
 
   [v0.6.0]: https://github.com/pgxn/meta/compare/v0.5.2...v0.6.0
   [Cross]: https://github.com/cross-rs/cross/
+    "“Zero setup” cross compilation and “cross testing” of Rust crates
+  [API Server Meta API]: https://github.com/pgxn/pgxn-api/wiki/meta-api#api-server-structure
+  [support for Solaris 11]: https://github.com/cross-rs/cross/issues/1599
+    "cross-rs/cross#1599: Support Solaris 11"
 
 ## [v0.5.2] — 2025-01-07
 

--- a/schema/v1/api-extras.schema.json
+++ b/schema/v1/api-extras.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pgxn.org/meta/v1/api-extras.schema.json",
+  "title": "API Extras",
+  "type": "object",
+  "description": "Additional properties added to distribution metadata by the [API Server Meta API](https://github.com/pgxn/pgxn-api/wiki/meta-api#api-server-structure).",
+  "properties": {
+    "docs": { "$ref": "docs.schema.json" },
+    "special_files": { "$ref": "special_files.schema.json" },
+    "releases": { "$ref": "releases.schema.json" }
+  }
+}

--- a/schema/v1/docs.schema.json
+++ b/schema/v1/docs.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pgxn.org/meta/v1/docs.schema.json",
+  "title": "Documentation",
+  "type": "object",
+  "description": "This property describes the documentation included a distribution. Only included in the [API Server Meta API](https://github.com/pgxn/pgxn-api/wiki/meta-api#api-server-structure).",
+  "propertyNames": { "type": "string" },
+  "minProperties": 1,
+  "additionalProperties": {
+    "type": "object",
+    "properties": {
+      "title": { "type": "string" },
+      "abstract": { "type": "string" }
+    },
+    "required": ["title"]
+  },
+  "examples": [
+    {
+      "README": {
+        "title": "pgTAP 0.25.0"
+      },
+      "doc/pgtap": {
+        "title": "pgTAP 0.25.0",
+        "abstract": "pgTAP Documentation"
+      }
+    }
+  ]
+}

--- a/schema/v1/extension.schema.json
+++ b/schema/v1/extension.schema.json
@@ -6,9 +6,8 @@
   "type": "object",
   "properties": {
     "file": {
-      "type": "string",
-      "description": "The value must contain a relative file path from the root of the distribution to the file containing the extension. The path must be specified with unix conventions.",
-      "minLength": 1
+      "$ref": "path.schema.json",
+      "description": "The value must contain a relative file path from the root of the distribution to the file containing the extension. The path must be specified with unix conventions."
     },
     "version": {
       "$ref": "version.schema.json",
@@ -20,8 +19,12 @@
       "minLength": 1
     },
     "docfile": {
+      "$ref": "path.schema.json",
+      "description": "The value must contain a relative file path from the root of the distribution to the file containing documentation for the extension. The path must be specified with unix conventions."
+    },
+    "docpath": {
       "type": "string",
-      "description": "The value must contain a relative file path from the root of the distribution to the file containing documentation for the extension. The path must be specified with unix conventions.",
+      "description": "The path to the documentation file for the extension, sans file name suffix. Added by the [API Server Meta API](https://github.com/pgxn/pgxn-api/wiki/meta-api#api-server-structure).",
       "minLength": 1
     }
   },

--- a/schema/v1/no_index.schema.json
+++ b/schema/v1/no_index.schema.json
@@ -31,15 +31,13 @@
           "minItems": 1,
           "uniqueItems": true,
           "items": {
-            "type": "string",
-            "description": "Relative path in unix convention to a file to ignore.",
-            "minLength": 1
+            "$ref": "path.schema.json",
+            "description": "Relative path in unix convention to a file to ignore."
           }
         },
         {
-          "type": "string",
-          "description": "Relative path in unix convention to a file to ignore.",
-          "minLength": 1
+          "$ref": "path.schema.json",
+          "description": "Relative path in unix convention to a file to ignore."
         }
       ]
     }

--- a/schema/v1/path.schema.json
+++ b/schema/v1/path.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pgxn.org/meta/v1/path.schema.json",
+  "title": "Path",
+  "description": "A *Path* is a string with a relative file path that identifies a file in the Distribution. The path **MUST** be specified with Unix conventions.",
+  "type": "string",
+  "minLength": 2,
+  "format": "path",
+  "$comment": "https://regex101.com/r/d49AVj",
+  "examples": ["Makefile", "Changes", "doc/pair.md"]
+}

--- a/schema/v1/release.schema.json
+++ b/schema/v1/release.schema.json
@@ -7,6 +7,7 @@
   "unevaluatedProperties": false,
   "allOf": [
     { "$ref": "base.schema.json" },
+    { "$ref": "api-extras.schema.json" },
     {
       "properties": {
         "user": {

--- a/schema/v1/releases.schema.json
+++ b/schema/v1/releases.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pgxn.org/meta/v1/releases.schema.json",
+  "title": "Releases",
+  "type": "object",
+  "description": "This object provides a complete history of all releases of the distribution, including those that were released after *this* release. Added by the [API Server Meta API](https://github.com/pgxn/pgxn-api/wiki/meta-api#api-server-structure).",
+  "minProperties": 1,
+  "properties": {
+    "stable": { "$ref": "#/$defs/list" },
+    "unstable": { "$ref": "#/$defs/list" },
+    "testing": { "$ref": "#/$defs/list" }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "list": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "properties": {
+          "date": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The timestamp for when the release was made.",
+            "examples": ["2024-09-12T19:56:49Z"]
+          },
+          "version": {
+            "$ref": "version.schema.json",
+            "description": "The release version. Its value must be a [SemVer](https://semver.org)."
+          }
+        },
+        "required": ["date", "version"],
+        "additionalProperties": false
+      }
+    }
+  }
+}

--- a/schema/v1/special_files.schema.json
+++ b/schema/v1/special_files.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pgxn.org/meta/v1/special_files.schema.json",
+  "title": "Special Files",
+  "type": "array",
+  "items": { "$ref": "path.schema.json" },
+  "description": "Lists the paths to special files in the distribution, such as `Changes`, `README`, `INSTALL`, `License`, and others.",
+  "minItems": 1,
+  "uniqueItems": true,
+  "examples": [["Changes", "README.md", "META.json", "Makefile"]]
+}

--- a/src/release/tests.rs
+++ b/src/release/tests.rs
@@ -45,6 +45,13 @@ fn test_corpus() -> Result<(), Error> {
               "user": payload.user,
               "date": payload.date,
               "sha1": "0389be689af6992b4da520ec510d147bae411e8b",
+              "docs": {"README": { "title": "pgTAP 0.25.0" }},
+              "special_files": ["Changes"],
+              "releases": {
+                "stable": [
+                  { "version": "0.25.0", "date": "2024-09-12T20:39:11Z" },
+                ],
+              },
             }),
         ),
         (2, certs),

--- a/src/tests/v2.rs
+++ b/src/tests/v2.rs
@@ -54,46 +54,7 @@ fn test_v2_semver() -> Result<(), Error> {
 
 #[test]
 fn test_v2_path() -> Result<(), Error> {
-    // Load the schemas and compile the path schema.
-    let mut compiler = new_compiler("schema/v2")?;
-    let mut schemas = Schemas::new();
-    let id = id_for(SCHEMA_VERSION, "path");
-    let idx = compiler.compile(&id, &mut schemas)?;
-
-    // Test valid paths.
-    for valid in [
-        json!("\\foo.md"),
-        json!("this\\and\\that.txt"),
-        json!("/absolute/path"),
-        json!("C:\\foo"),
-        json!("README.txt"),
-        json!(".git"),
-        json!("src/pair.c"),
-        json!(".github/workflows/"),
-        json!("this\\\\and\\\\that.txt"),
-    ] {
-        if let Err(e) = schemas.validate(&valid, idx) {
-            panic!("{} failed: {e}", valid);
-        }
-    }
-
-    // Test invalid paths.
-    for invalid in [
-        json!("../outside/path"),
-        json!("thing/../other"),
-        json!(null),
-        json!(""),
-        json!({}),
-        json!([]),
-        json!(true),
-        json!(null),
-        json!(42),
-    ] {
-        if schemas.validate(&invalid, idx).is_ok() {
-            panic!("{} unexpectedly passed!", invalid)
-        }
-    }
-    Ok(())
+    test_path(SCHEMA_VERSION)
 }
 
 #[test]


### PR DESCRIPTION
The API Server adds additional properties to the [Meta API], an which here is called Release (because it contains release metadata). This caused validation to fail for metadata fetched from api.pgxn.org.

Extend the validation of Release metadata to optionally include these properties. Define a new v1 schema, `api-extras.schema.json`, and add it to `release.schema.json`. Like the existing schemas, it applies strict validation for the new properties.

Since the new schemas validate file paths, copy `path.schema.json` from the v2 schemas and apply it to the other paths in the v1 schema.

Increment to v0.6.0 and prep for release.

  [Meta API]: https://github.com/pgxn/pgxn-api/wiki/meta-api#api-server-structure