### PR TITLE
Add tag limit and glob format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ All notable changes to this project will be documented in this file. It uses the
   [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
     "Semantic Versioning 2.0.0"
 
+## [v0.6.1] — Unreleased
+
+### ⚡ Improvements
+
+*   Added a limit to the number of tags in the v2 schema to 32.
+*   Added glob format and validation using [wax].
+*   Disallow parent directory components (`..`) in globs (already disallowed
+    in paths)
+*   Disallow current directory components (`.`) in paths and globs except at
+    the start of the expression (e.g., `./README`).
+
+  [v0.6.1]: https://github.com/pgxn/meta/compare/v0.6.0...v0.6.1
+  [wax]: https://crates.io/crates/wax
+
 ## [v0.6.0] — 2025-03-25
 
 ### ⬆️ Dependency Updates

--- a/schema/v2/glob.schema.json
+++ b/schema/v2/glob.schema.json
@@ -5,7 +5,7 @@
   "description": "*Glob* defines a pattern to identify one or more files in the distribution.",
   "type": "string",
   "minLength": 2,
-  "format": "",
+  "format": "glob",
   "pattern": "^(?:[^\\\\]|\\\\\\\\)+$",
   "$comment": "https://regex101.com/r/d49AVj; Crates: fast-glob or wax",
   "examples": ["/.git", "src/private.c", "doc/*.html"]

--- a/schema/v2/tags.schema.json
+++ b/schema/v2/tags.schema.json
@@ -5,6 +5,7 @@
   "description": "A list of keywords that describe the distribution.",
   "type": "array",
   "minItems": 1,
+  "maxItems": 32,
   "uniqueItems": true,
   "items": {
     "title": "Tag",

--- a/src/tests/common.rs
+++ b/src/tests/common.rs
@@ -200,6 +200,14 @@ pub fn test_tags_schema(mut compiler: Compiler, version: u8) -> Result<(), Error
         }
     }
 
+    if version > 1 {
+        let strings: [String; 33] = core::array::from_fn(|i| format!("string {i}"));
+        let val = serde_json::to_value(&strings[..]).unwrap();
+        if schemas.validate(&val, idx).is_ok() {
+            panic!("too many tags unexpectedly passed!")
+        }
+    }
+
     Ok(())
 }
 

--- a/src/tests/v2.rs
+++ b/src/tests/v2.rs
@@ -76,7 +76,7 @@ fn test_v2_glob() -> Result<(), Error> {
         json!("foo.?tml"),
         json!("[xX]_*.*"),
         json!("[a-z]*.txt"),
-        json!("this\\\\and\\\\that.txt"),
+        json!("**/*.(?i){jpg,jpeg,png}"),
     ] {
         if let Err(e) = schemas.validate(&valid, idx) {
             panic!("{} failed: {e}", valid);
@@ -86,6 +86,8 @@ fn test_v2_glob() -> Result<(), Error> {
     // Test invalid globs.
     for invalid in [
         json!("this\\and\\that.txt"),
+        json!("/src/../pair.c"),
+        json!("../outside/path"),
         json!(null),
         json!(""),
         json!("C:\\foo"),
@@ -1346,10 +1348,6 @@ fn test_v2_ignore() -> Result<(), Error> {
         ("foo.?tml", json!(["foo.?tml"])),
         ("[xX]_*.*", json!(["[xX]_*.*"])),
         ("[a-z]*.txt", json!(["[a-z]*.txt"])),
-        (
-            "this\\\\and\\\\that.txt",
-            json!(["this\\\\and\\\\that.txt"]),
-        ),
         (
             "multiple files",
             json!(["ignore_me.txt", "*.tmp", ".git*",]),


### PR DESCRIPTION
Use [wax] to validate globs. Since it checks for both `.` and `..` components, disallow both for paths and globs, except at the start of an expression.  May or may not switch away from wax in the future, since its syntax is somewhat different from gitignore. For now, though, the RFC has been [updated] to reflect this change.

Also limit the number of tags to 32, also reflecting a recent RFC change.

  [wax]: https://crates.io/crates/wax
  [updated]: https://github.com/pgxn/rfcs/pull/3/commits/4021dee